### PR TITLE
🛡️ Sentinel: Fix binary planting vulnerability in PATH discovery

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -13,3 +13,8 @@
 **Prevention:**
 1. Always check the return value of `close` on piped filehandles: `close($fh) or die "Pipe failed: $!"`.
 2. Explicitly validate the existence and executability of external binaries in the `PATH` at startup, and use their absolute paths to ensure the intended tools are being invoked.
+
+## 2025-05-14 - Binary Planting in PATH Discovery
+**Vulnerability:** Binary discovery logic that iterates through the `PATH` was susceptible to binary planting if the current directory (`.`) or an empty string was present in the `PATH`.
+**Learning:** Even when manually searching the `PATH` instead of relying on the shell, one must explicitly ignore untrusted directories like the current working directory to prevent execution of malicious binaries placed there.
+**Prevention:** Explicitly skip empty entries and `.` when iterating through `File::Spec->path()`.

--- a/svre.pl
+++ b/svre.pl
@@ -73,6 +73,8 @@ my $use_translocation = 1;
 
 my $samtools_command = '';
 foreach my $p (File::Spec->path()) {
+    # Security: skip current directory in PATH to prevent binary planting
+    next if $p eq '' or $p eq '.';
     my $full_path = File::Spec->catfile($p, "samtools");
     if (-x $full_path) {
         $samtools_command = File::Spec->rel2abs($full_path);
@@ -82,6 +84,8 @@ foreach my $p (File::Spec->path()) {
 
 my $R_command = '';
 foreach my $p (File::Spec->path()) {
+    # Security: skip current directory in PATH to prevent binary planting
+    next if $p eq '' or $p eq '.';
     my $full_path = File::Spec->catfile($p, "Rscript");
     if (-x $full_path) {
         $R_command = File::Spec->rel2abs($full_path);


### PR DESCRIPTION
🛡️ Sentinel has identified and fixed a **binary planting** (untrusted path execution) vulnerability in `svre.pl`.

### 💡 Vulnerability
The script manually searches the `PATH` environment variable to locate the `samtools` and `Rscript` binaries. It did not explicitly ignore the current directory (`.`) or empty entries in the `PATH` (which also signify the current directory on many systems).

### 🎯 Impact
An attacker could place a malicious executable named `samtools` or `Rscript` in a directory and trick a user into running `svre.pl` from that directory. If the user's `PATH` contains `.` or an empty entry, the malicious binary would be executed instead of the legitimate system tool.

### 🔧 Fix
Updated the binary discovery loops for `samtools` and `Rscript` in `svre.pl` to explicitly skip entries that are empty strings or `.`.

### ✅ Verification
1.  Created a dummy `samtools` in the current directory.
2.  Verified that a script mimicking the original logic would find and use the local dummy binary when `PATH` included `.` or was prefixed with `:`.
3.  Verified that the updated logic successfully ignores the local dummy binary and correctly fails if the binary is not found in other `PATH` directories.

Security learnings have been documented in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [13207248372295120770](https://jules.google.com/task/13207248372295120770) started by @swainechen*