### PR TITLE
🛡️ Sentinel: Hardening input validation and fixing logical error in SV merging

### DIFF
--- a/svre.pl
+++ b/svre.pl
@@ -28,7 +28,7 @@ use File::Spec;
 #@@@@@@@@@@@
 # Variables 
 #@@@@@@@@@@@
-my $tempdir = File::Temp::tempdir("svre_XXXXXXXX", TMPDIR => 1, CLEANUP => 1);
+my $tempdir = File::Spec->rel2abs(File::Temp::tempdir("svre_XXXXXXXX", TMPDIR => 1, CLEANUP => 1));
 my $command_line = join (" ", $0, @ARGV); chomp $command_line;
 my $read;	# the main data file
 my $r1 = "";	# sam/bam file 1
@@ -163,6 +163,12 @@ GetOptions(
   "mapq=i" => \$mapq_min,
   "quiet" => \$quiet
 );
+
+# Security: Validate user-provided and calculated parameters to prevent division-by-zero
+die "Error: bootstrap must be greater than 0\n" if $bootstrap <= 0;
+die "Error: fdr must be between 0 and 1\n" if $fdr <= 0 or $fdr >= 1;
+die "Error: ywindow must be greater than or equal to 0\n" if $ywin < 0;
+die "Error: cov must be greater than 0\n" if $cov_bin <= 0;
 
 if ($samtools_command eq '') {
     die "Error: samtools not found in PATH. Please install samtools.\n";
@@ -628,6 +634,7 @@ foreach $ref (keys %$pos) {
 undef %$pos;
 
 my $global_cdf = {};
+die "Error: No valid mapped reads found in input files.\n" if $global_total == 0;
 foreach $bin (sort keysort keys %$global_dist) {
   $global_dist->{$bin} = $global_dist->{$bin} / $global_total;
   if ($print_dist) {
@@ -1262,7 +1269,7 @@ if ($pval) {
         if ($merge_sv->{$k}->{type} eq $merge_sv->{$l}->{type}) {
           if ($merge_sv->{$k}->{type} eq "Translocation") {
             if ($merge_sv->{$k}->{bp1}->{ref} eq $merge_sv->{$l}->{bp1}->{ref} && $merge_sv->{$k}->{bp2}->{ref} eq $merge_sv->{$l}->{bp2}->{ref}) {
-              if (sv::overlap($merge_sv->{$k}->{bp1}->{coord}, $merge_sv->{$l}->{bp1}->{coord}, $range_cluster) && sv::overlap($merge_sv->{$k}->{bp2}->{coord}, $merge_sv->{$l}->{bp2}->{coord}), $range_cluster) {
+              if (sv::overlap($merge_sv->{$k}->{bp1}->{coord}, $merge_sv->{$l}->{bp1}->{coord}, $range_cluster) && sv::overlap($merge_sv->{$k}->{bp2}->{coord}, $merge_sv->{$l}->{bp2}->{coord}, $range_cluster)) {
                 $merged = 1;
                 $merge_sv->{$k}->{bp1}->{coord} = sv::range([ $merge_sv->{$k}->{bp1}->{coord}, $merge_sv->{$l}->{bp1}->{coord} ], $range_cluster);
                 $merge_sv->{$k}->{bp2}->{coord} = sv::range([ $merge_sv->{$k}->{bp2}->{coord}, $merge_sv->{$l}->{bp2}->{coord} ], $range_cluster);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability:
1. Missing input validation for command-line parameters (`-bootstrap`, `-fdr`, `-ywindow`, `-cov`) could lead to division-by-zero or undefined behavior.
2. A potential division-by-zero error in the global distribution calculation if no valid reads are found.
3. A critical logic bug in the structural variation merging code where a misplaced parenthesis and extra comma caused a conditional check to always evaluate as true.
4. Use of a relative path for the temporary directory could be problematic if the script changes its working directory.

🎯 Impact:
1. The script would crash or produce incorrect results with malformed input.
2. The `overlap` logic bug resulted in incorrect merging of structural variation predictions, potentially leading to false positives or noisy output.
3. Relative paths for temp dirs can lead to cleanup failures or security risks if external tools are used with a different working directory.

🔧 Fix:
1. Added bounds checking for `$bootstrap`, `$fdr`, `$ywin`, and `$cov_bin` after `GetOptions`.
2. Added a check for `$global_total == 0` before calculating the global distribution.
3. Corrected the `sv::overlap` call in the structural variation merging logic.
4. Wrapped `File::Temp::tempdir` in `File::Spec->rel2abs`.

✅ Verification:
1. Verified syntax with `perl -I. -c svre.pl`.
2. Tested input validation with invalid values for `-bootstrap`, `-fdr`, etc., and confirmed the script terminates with a clear error message.
3. Inspected the code around the `overlap` fix to ensure the logic is now correct.

---
*PR created automatically by Jules for task [5512515325216499902](https://jules.google.com/task/5512515325216499902) started by @swainechen*