### PR TITLE
🛡️ Sentinel: Fix division-by-zero vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,10 @@
 **Vulnerability:** Binary discovery logic that iterates through the `PATH` was susceptible to binary planting if the current directory (`.`) or an empty string was present in the `PATH`.
 **Learning:** Even when manually searching the `PATH` instead of relying on the shell, one must explicitly ignore untrusted directories like the current working directory to prevent execution of malicious binaries placed there.
 **Prevention:** Explicitly skip empty entries and `.` when iterating through `File::Spec->path()`.
+
+## 2026-04-24 - Division-by-Zero in Numerical Calculations and Progress Reporting
+**Vulnerability:** The application was susceptible to script termination (DoS) due to division-by-zero when processing small or invalid genomic data, or when using low bootstrap values.
+**Learning:** In Perl, division by zero is a fatal error. Genomic tools often perform divisions based on derived values (like genome size or median distance) which can be zero if input data is malformed or filter-heavy.
+**Prevention:**
+1. Always validate numeric command-line arguments and derived values (e.g., `$ywin`, `$genome_size`) before using them as divisors.
+2. In loop-based progress reporting, ensure the modulo divisor is at least 1 using `List::Util::max(1, ...)` to handle small iteration counts safely.

--- a/sv.pm
+++ b/sv.pm
@@ -461,7 +461,7 @@ sub bootstrap {
     $random = 0;
     $i = 1;
 
-    $progress = $times % int($bootstrap/20);
+    $progress = $times % max(1, int($bootstrap/20));
     print STDERR "*" if !$quiet && $progress == 0;
     while ($i <= $cov) {
       push @random, rand();

--- a/svre.pl
+++ b/svre.pl
@@ -597,6 +597,8 @@ if ($ywin == 0) {
   $ywin = int($median_dist + (-$median_dist % 50))/2 if $median_dist > 0;
   $ywin = int(-$median_dist + ($median_dist % 50))/2 if $median_dist < 0;
 }
+# Security: ensure ywindow is non-zero to prevent division-by-zero
+die "Error: ywindow cannot be 0. Please check your input files or provide a ywindow using -ywindow.\n" if $ywin == 0;
 
 # can set global distribution and counts now
 # should collapse into bins instead of distances also
@@ -671,6 +673,8 @@ foreach $key (keys %$refh) {
   }
   $genome_size += $i;
 }
+# Security: ensure genome_size is non-zero to prevent division-by-zero
+die "Error: Total genome size cannot be 0. Please check your input files.\n" if $genome_size == 0;
 
 printf STDERR ("Total genome size (rounded to bin size): %d (%d Y-bins)\n", $genome_size, 2*$genome_size/$ywin) if !$quiet;
 


### PR DESCRIPTION
I have identified and fixed potential division-by-zero vulnerabilities in `svre.pl` and `sv.pm`. These could lead to script termination (Denial of Service) when processing certain edge-case genomic data or when using specific command-line parameters.

Key changes:
1.  **`sv.pm`**: Updated the `bootstrap` function to ensure the progress-reporting modulo divisor is at least 1, preventing a crash for small bootstrap values.
2.  **`svre.pl`**: Added explicit validation checks for `$ywin` (y-window bin size) and `$genome_size` before they are used as divisors in calculations.
3.  **`.jules/sentinel.md`**: Logged the vulnerability pattern and prevention strategies in the Sentinel journal.

I verified the fix for `sv::bootstrap` using a reproduction script and performed syntax checks on all modified files.

---
*PR created automatically by Jules for task [17727887439688281212](https://jules.google.com/task/17727887439688281212) started by @swainechen*