### PR TITLE
🛡️ Sentinel: Fix DoS vulnerability in SNR calculation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -29,3 +29,8 @@
 **Prevention:**
 1. Always validate numeric command-line arguments and derived values (e.g., `$ywin`, `$genome_size`) before using them as divisors.
 2. In loop-based progress reporting, ensure the modulo divisor is at least 1 using `List::Util::max(1, ...)` to handle small iteration counts safely.
+
+## 2026-04-26 - Infinite Loops and Division-by-Zero in SNR Calculation
+**Vulnerability:** The `sv::snr` function was susceptible to infinite loops and division-by-zero when processing uniform or insufficient relative entropy data.
+**Learning:** Signal-to-Noise Ratio (SNR) calculations often involve partitioning data based on range. If the range is zero (all values identical) or data points are insufficient, calculations for resolution or weights can lead to zero steps in loops or division-by-zero errors.
+**Prevention:** Explicitly validate that the data set has at least two elements and a non-zero range before proceeding with partitioning-based calculations.

--- a/sv.pm
+++ b/sv.pm
@@ -392,6 +392,10 @@ sub snr {
   }
   @ric = sort {$a <=> $b} @ric;
 
+  # Security: return 0 if there are not enough elements or no variation to avoid division by zero or infinite loops
+  return 0 if scalar(@ric) < 2;
+  return 0 if $ric[$#ric] == $ric[0];
+
   if ($resolution > ($ric[$#ric] - $ric[0])/1000) {
     $resolution = ($ric[$#ric] - $ric[0])/1000;
   }


### PR DESCRIPTION
Identified a Denial of Service (DoS) vulnerability in the `sv::snr` function within `sv.pm`. 

When the input data to `sv::snr` is uniform (all values are identical) or has fewer than two elements, the code would calculate a `$resolution` of zero. This caused an infinite loop in the subsequent `for` loop, as the loop counter would never advance. Additionally, uniform data could lead to division-by-zero errors in the weight calculations.

The fix adds explicit validation checks after the data has been collected and sorted, ensuring there are at least two distinct values before proceeding with the SNR calculation.

Severity: MEDIUM (DoS risk)
Fix: Added early return guards in `sv::snr`.
Verification: Verified with a custom test script mocking the environment's missing dependencies.

---
*PR created automatically by Jules for task [8356223683390927856](https://jules.google.com/task/8356223683390927856) started by @swainechen*