### PR TITLE
🛡️ Sentinel: Fix Infinite Loop DoS in Binary Search

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -41,3 +41,8 @@
 **Prevention:**
 1. Always bound the number of iterations in search or optimization loops by making the step size proportional to the total range.
 2. Use transient data references or direct indexing instead of storing redundant copies of data subsets in hashes or arrays within loops.
+
+## 2026-04-28 - Infinite Loop DoS in Binary Search via NaN values
+**Vulnerability:** The `sv::binary_search` function was susceptible to infinite loops when encountering `NaN` values in the input array.
+**Learning:** In Perl, all numeric comparisons (`==`, `<`, `>`) with `NaN` return false. If a binary search loop depends solely on these comparisons to update its bounds, it will never terminate if it lands on a `NaN`.
+**Prevention:** Ensure search loops have a terminal `else` or fallback condition that breaks the loop if no comparison is met, and sanitize numeric input data to exclude `NaN` or non-numeric values before processing.

--- a/sv.pm
+++ b/sv.pm
@@ -386,7 +386,8 @@ sub snr {
 
   foreach $w1 (keys %$ri) {	# ref
     foreach $w2 (keys %{$ri->{$w1}}) {	# bin
-      push @ric, $ri->{$w1}->{$w2}->{entropy};
+      my $e = $ri->{$w1}->{$w2}->{entropy};
+      push @ric, $e if isfloat($e);
     }
   }
   @ric = sort {$a <=> $b} @ric;
@@ -528,12 +529,13 @@ sub binary_search {
       $low = $try;
       $high = $try;
       last;
-    }
-    if ($array->[$try] < $value) {
-      $low = $try + 1; 
-    }
-    if ($array->[$try] > $value) {
-      $high = $try - 1; 
+    } elsif ($array->[$try] < $value) {
+      $low = $try + 1;
+    } elsif ($array->[$try] > $value) {
+      $high = $try - 1;
+    } else {
+      # This can happen if values are not comparable (e.g. NaN)
+      last;
     }
   }
 

--- a/test_nan_dos.pl
+++ b/test_nan_dos.pl
@@ -1,0 +1,47 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+# Mocking modules before loading sv.pm
+BEGIN {
+    $INC{'Math/Round.pm'} = 1;
+    $INC{'Math/CDF.pm'} = 1;
+    $INC{'Math/Trig.pm'} = 1;
+    $INC{'Math/BigFloat.pm'} = 1;
+}
+
+package Math::Trig;
+sub pi { return 3.14159265358979; }
+
+package sv;
+sub isfloat { return 1; } # simplified
+use constant pi => 3.14159265358979;
+
+package main;
+use lib '.';
+require sv;
+
+my @array = (1, 2, "nan", 4, 5);
+# Note: "nan" in Perl might be treated as string or number depending on context.
+# Let's use an actual NaN if possible.
+my $nan = 0 + "nan";
+
+@array = (1, 2, $nan, 4, 5);
+# The array must be sorted for binary_search, but NaN doesn't sort well.
+# sv::snr sorts the array: @ric = sort {$a <=> $b} @ric;
+@array = sort {$a <=> $b} @array;
+
+print "Array: @array\n";
+
+print "Calling sv::binary_search with NaN in array...\n";
+eval {
+    local $SIG{ALRM} = sub { die "TIMEOUT\n" };
+    alarm(3);
+    sv::binary_search(\@array, 3);
+    alarm(0);
+};
+if ($@) {
+    print "Result: $@";
+} else {
+    print "Completed without timeout.\n";
+}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Infinite Loop DoS in Binary Search

This PR addresses a critical Denial of Service (DoS) vulnerability in the structural variation detection module (`sv.pm`). 

### 💡 Vulnerability:
The `sv::binary_search` function used a `while` loop with numeric comparisons (`==`, `<`, `>`) to find elements in a sorted array. In Perl, comparisons with `NaN` (Not-a-Number) always return false. If the search algorithm encountered a `NaN` value, the loop pointers would never update, leading to an infinite loop and 100% CPU usage.

### 🎯 Impact:
An attacker could potentially trigger this by providing malformed genomic data that results in `NaN` during intermediate calculations (like relative entropy). This would cause the `svre.pl` script to hang indefinitely.

### 🔧 Fix:
1.  **Hardened `binary_search`**: Restructured the comparison logic to use an `if/elsif/else` chain where the `else` block explicitly terminates the loop if no comparison matches (handling non-comparable values like `NaN`).
2.  **Defensive Filtering in `snr`**: Added a check in the `sv::snr` function to filter out non-numeric values using the existing `isfloat` helper before they reach the binary search or statistical calculation logic.

### ✅ Verification:
- Created a reproduction script `test_nan_dos.pl` that confirmed the hang in the original code and verified the fix.
- Ran `test_snr_security.pl` to ensure that standard SNR calculations remain correct and efficient.
- Verified that all changes are under the 50-line limit.

---
*PR created automatically by Jules for task [530356421813638290](https://jules.google.com/task/530356421813638290) started by @swainechen*