### PR TITLE
🛡️ Sentinel: [HIGH] Fix Algorithmic Complexity (DoS) in chromosome ordering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -51,3 +51,8 @@
 **Vulnerability:** The `sv::range` function used a point-expansion algorithm that converted genomic intervals into individual points. For large ranges, this caused massive memory allocation and CPU spikes ($O(\text{TotalRangeSize})$).
 **Learning:** In Perl, lexical variables `$a` and `$b` can shadow the global variables used by the `sort` built-in, leading to broken comparisons in algorithms that rely on sorting. Genomic data often contains extremely large intervals that must be processed as intervals rather than collections of points.
 **Prevention:** Use interval-merging algorithms with $O(N \log N)$ complexity for range operations. Avoid using `$a` and `$b` as lexical argument names in subroutines to prevent interference with the `sort` built-in.
+
+## 2026-05-15 - Algorithmic Complexity DoS in Chromosome Ordering
+**Vulnerability:** The chromosome ordering logic in `svre.pl` used nested loops ($O(N^2)$) to group chromosomes by size. When processing reference genomes with thousands of chromosomes of identical size (e.g., fragmented assemblies), this led to extreme CPU usage and memory exhaustion due to the list size exploding.
+**Learning:** Naive grouping and sorting algorithms using nested `grep` calls can easily exhibit quadratic or worse complexity. Additionally, incorrect logic for filtering chromosomes (comparing a hash reference to a string) caused valid data to be dropped or misaligned.
+**Prevention:** Always use efficient $O(N \log N)$ sorting functions (like Perl's `sort`) with appropriate tie-breakers for stability. Ensure filtering logic correctly uses `exists` or value checks instead of comparing references to strings.

--- a/svre.pl
+++ b/svre.pl
@@ -827,17 +827,16 @@ foreach $ref (keys %$count) {
 die "Error: ywin is 0, cannot calculate no_of_ybins\n" if $ywin == 0;
 my $no_of_ybins = round($genome_size*2 / $ywin); 
 
-my @refsize = sort {$b<=>$a} values %$refh;
-my @reforder = ();
+# Security: Fix O(N^2) complexity in chromosome ordering and correct logic errors.
+# Sort chromosome names by size (descending), using name as tie-breaker for stability.
+my @reforder = sort { $refh->{$b} <=> $refh->{$a} || $a cmp $b } keys %$refh;
+my @refsize = map { $refh->{$_} } @reforder;
+
+# Only process chromosomes that actually have data, in the order defined by @reforder.
+my @refnames = grep { exists $count->{$_} } @reforder;
+
 my $refnames = "";
 my $refsizes = "";
-foreach my $i (@refsize) {
-  push @reforder, grep { $refh->{$_} == $i } keys %$refh; 
-}
-my @refnames = keys %$count;
-foreach my $name (@reforder) {
-  push @refnames, grep { $count->{$_} eq $name } keys %$count; 
-}
 
 #@@@@@@@@@@@@@@@@@@@@@@
 # P-value calculations
@@ -864,7 +863,7 @@ my $significant = {};
 
 # adjust the p-values by Benjamini-Yekutieli
 if ($pval) {
-  foreach $ref (@reforder) {
+  foreach $ref (@refnames) {
     foreach $bin (keys %{$ri->{$ref}}) {
       push @ent, $ri->{$ref}->{$bin}->{entropy};
     }
@@ -902,7 +901,7 @@ if ($pval) {
 }
 
 print STDERR "Generating output:\n";
-foreach $ref (@reforder) {
+foreach $ref (@refnames) {
   print STDERR "  $ref ... " if !$quiet;
   foreach $bin (sort {$a <=> $b} keys %{$ri->{$ref}}) {
     print $ih join ("\t",


### PR DESCRIPTION
I identified and fixed an Algorithmic Complexity vulnerability in `svre.pl` that could lead to a Denial of Service (DoS). The original code used a nested loop structure ($O(N^2)$) to order chromosomes by size, which would explode in time and memory when handling many chromosomes of the same size (common in fragmented genomic assemblies). I replaced this with an efficient $O(N \log N)$ sort. I also fixed a logic error that caused incorrect filtering of chromosomes during results generation.

---
*PR created automatically by Jules for task [3407243292725291039](https://jules.google.com/task/3407243292725291039) started by @swainechen*