### PR TITLE
🛡️ Sentinel: Fix Algorithmic Complexity DoS in sv::unwind_distance

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -66,3 +66,8 @@
 **Vulnerability:** The `sv::refmod` and `sv::refadd` functions used `while` loops to normalize genomic coordinates against a reference length. For extremely large coordinates or small reference lengths, this resulted in $O(N)$ complexity, leading to CPU exhaustion and script hangs (DoS).
 **Learning:** Naive normalization using iterative subtraction/addition is dangerous when the input range is untrusted or unbounded.
 **Prevention:** Always use $O(1)$ arithmetic (like the modulo operator or direct division) for coordinate normalization instead of loops.
+
+## 2026-05-22 - Algorithmic Complexity DoS in sv::unwind_distance
+**Vulnerability:** The `sv::unwind_distance` function performed a linear scan ($O(N)$) over an entire genomic bin range (which could be extremely large depending on user-provided `binsize`). This led to CPU exhaustion (DoS) when processing bins with large coordinate spans.
+**Learning:** Iterating through every integer in a genomic range is a common DoS vector in bioinformatics tools. Replacing linear scans with iterations over observed data points (hash keys) protects against large ranges, but can introduce performance regressions if the entire dataset is scanned repeatedly.
+**Prevention:** Use a combination of coordinate-based iteration and caching. Store sorted genomic coordinates for each chromosome and use binary search to locate starting positions within bins. This achieves $O(\log N + \text{DataPointsInBin})$ complexity, providing both security and high performance.

--- a/sv.pm
+++ b/sv.pm
@@ -1147,7 +1147,29 @@ sub unwind_distance {
   # multiple reads mapping to the same position, and their pairs map on both
   # sides of where we are - but hopefully this doesn't happen too much given
   # the amount of coverage that would be needed
-  foreach $i ($bin .. $bin + $ri->{$ref}->{$bin}->{binsize}) {
+  my $bin_end = $bin + $ri->{$ref}->{$bin}->{binsize};
+  # Security: To prevent algorithmic complexity DoS, iterate only over observed
+  # coordinates in the hash instead of a linear scan of the entire bin range.
+  # Use a cache for sorted keys to maintain O(N log N) total performance
+  # while avoiding O(RangeSize) DoS.
+  if (!defined $precount->{$ref}) {
+    return("error - no data for ref");
+  }
+
+  # Persistent cache for sorted coordinates within the 'sv' package namespace
+  our $UNWIND_COORD_CACHE;
+  if (!defined $UNWIND_COORD_CACHE->{$precount}->{$ref}) {
+    my @coords = sort { $a <=> $b } keys %{$precount->{$ref}};
+    $UNWIND_COORD_CACHE->{$precount}->{$ref} = \@coords;
+  }
+  my $coords = $UNWIND_COORD_CACHE->{$precount}->{$ref};
+
+  my ($start_idx, $unused_end) = binary_search($coords, $bin);
+  for (my $idx = $start_idx; $idx <= $#$coords; $idx++) {
+    $i = $coords->[$idx];
+    last if $i > $bin_end;
+    next if $i < $bin;
+
     next if !defined $precount->{$ref}->{$i}->{$dist};
     next if !defined $precount->{$ref}->{$i}->{pair};	# should never happen
     foreach $j (@{$precount->{$ref}->{$i}->{pair}}) {


### PR DESCRIPTION
This PR fixes an algorithmic complexity Denial of Service (DoS) vulnerability in the `sv::unwind_distance` function.

### 🚨 Severity: HIGH

### 💡 Vulnerability
The `sv::unwind_distance` function performed a linear scan of every integer coordinate within a genomic bin:
```perl
foreach $i ($bin .. $bin + $ri->{$ref}->{$bin}->{binsize}) { ... }
```
If a user provides a maliciously large `binsize`, this loop consumes excessive CPU cycles.

### 🎯 Impact
An attacker could cause the application to hang or consume all available CPU resources by providing input that results in large bin sizes.

### 🔧 Fix
1. Replaced the linear scan with an iteration over observed data points (hash keys).
2. Implemented a persistent coordinate cache (`our $UNWIND_COORD_CACHE`) to store sorted keys per chromosome, ensuring $O(N \log N)$ overhead is only paid once.
3. Used `sv::binary_search` to find the start of the bin in the sorted coordinates, making the lookup $O(\log N)$.
4. Added safety checks for undefined hash references.

### ✅ Verification
- Created `test_unwind_dos.pl` which demonstrated that execution time for a 10M bp bin dropped from ~28 seconds to ~0 seconds.
- Verified that correct results are still obtained by comparing output with the original logic on smaller datasets.
- Ran all existing security-related tests in the repository.

---
*PR created automatically by Jules for task [4994252560821484540](https://jules.google.com/task/4994252560821484540) started by @swainechen*