### PR TITLE
🛡️ Sentinel: Fix DoS vulnerabilities in entropy calculations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -71,3 +71,8 @@
 **Vulnerability:** The `sv::unwind_distance` function performed a linear scan ($O(N)$) over an entire genomic bin range (which could be extremely large depending on user-provided `binsize`). This led to CPU exhaustion (DoS) when processing bins with large coordinate spans.
 **Learning:** Iterating through every integer in a genomic range is a common DoS vector in bioinformatics tools. Replacing linear scans with iterations over observed data points (hash keys) protects against large ranges, but can introduce performance regressions if the entire dataset is scanned repeatedly.
 **Prevention:** Use a combination of coordinate-based iteration and caching. Store sorted genomic coordinates for each chromosome and use binary search to locate starting positions within bins. This achieves $O(\log N + \text{DataPointsInBin})$ complexity, providing both security and high performance.
+
+## 2026-05-24 - DoS via log(0) and Division-by-Zero in Entropy Calculations
+**Vulnerability:** The application was susceptible to runtime crashes (DoS) when calculating Relative Information Content (RIC) or bootstrapping if input data resulted in zero-valued probabilities or missing bins in the global distribution.
+**Learning:** In Perl, `log(0)` is a fatal error. Genomic data with extremely low coverage or skewed distributions can lead to zero-valued bins. Skipping these bins in summation is mathematically correct for entropy ($0 \log 0 = 0$) and prevents script termination.
+**Prevention:** Always guard `log()` and division operations with checks for positive arguments and non-zero denominators, especially when derived from data-dependent distributions.

--- a/sv.pm
+++ b/sv.pm
@@ -287,6 +287,7 @@ sub poisson {
 # return ln(poisson)
 sub poissonApprox {
   my ($lambda, $k) = @_;
+  return -1000 if $lambda <= 0; # ln(0) is undefined, return a small value
   my $a = $k * log($lambda);
   my $ln_poisson = $a - $lambda - factorialApprox($k);
   return $ln_poisson;
@@ -297,7 +298,7 @@ sub poissonApprox {
 # return ln(n!)
 sub factorialApprox {
   my $x = shift @_;
-  if( $x < 2 ){
+  if( !defined $x || $x < 2 ){
     return 0;
   } else {
     my $a = $x * log($x) - $x;
@@ -504,8 +505,10 @@ sub bootstrap {
 #    foreach $c (sort {$a<=>$b} keys %$bins) {}
     foreach $c (keys %$bins) {
       $freq_bin = $bins->{$c}/$cov;
-      $info_bin = $freq_bin * log($freq_bin/$prob_dist->{$c}); 
-      $info += $info_bin;
+      if ($freq_bin > 0 && $prob_dist->{$c} && $prob_dist->{$c} > 0) {
+        $info_bin = $freq_bin * log($freq_bin/$prob_dist->{$c});
+        $info += $info_bin;
+      }
     }
     $info_freq->{$info} += 1;
     $times++;
@@ -1092,7 +1095,9 @@ sub ric {
         $prob = $count->{$ref}->{$bin}->{$dist}/$rcount;
         $exp_prob = $global_dist->{$dist};
 
-        $info_w = $prob*(log($prob/$exp_prob));
+        if ($prob > 0 && $exp_prob && $exp_prob > 0) {
+          $info_w = $prob*(log($prob/$exp_prob));
+        }
         $info = $info + $info_w;
       }
       $ri->{$ref}->{$bin}->{rcount} = $rcount;

--- a/svre.pl
+++ b/svre.pl
@@ -649,8 +649,9 @@ exit if $print_dist;
 if (!$quiet) {
   print STDERR "Paired-end reads with one / both uniquely mapped: $single / $both\n";
   print STDERR "Median paired-end distance: $median_dist; Y-window bin size: $ywin\n";
-#  print STDERR "Average read length: ", int($read_length_total/(2*$both)),"\n";
+#  print STDERR "Average read length: ", ($both > 0 ? int($read_length_total/(2*$both)) : 0),"\n";
 }
+die "Error: No paired-end reads found where both reads are uniquely mapped. SV detection requires paired-end data.\n" if $both == 0;
 if ($range_cluster == 0) {
   $range_cluster = $median_dist;
 }
@@ -924,12 +925,18 @@ foreach $ref (@refnames) {
         next if $dist eq "pair";
         next if $dist eq "rcount";
         next if $dist eq "pos";
+        my $prob = $count->{$ref}->{$bin}->{$dist}/$ri->{$ref}->{$bin}->{rcount};
+        my $exp_prob = $global_dist->{$dist};
+        my $info_w = 0;
+        if ($prob > 0 && $exp_prob && $exp_prob > 0) {
+          $info_w = $prob * log($prob/$exp_prob);
+        }
         print $dh join ("\t",
           $dist,
           $count->{$ref}->{$bin}->{$dist},
           $global_dist->{$dist},
-          $count->{$ref}->{$bin}->{$dist}/$ri->{$ref}->{$bin}->{rcount},
-          $count->{$ref}->{$bin}->{$dist}/$ri->{$ref}->{$bin}->{rcount}*log($count->{$ref}->{$bin}->{$dist}/$ri->{$ref}->{$bin}->{rcount}/$global_dist->{$dist})), "\n";
+          $prob,
+          $info_w), "\n";
       }
       if (defined $count->{$ref}->{$bin}->{pair} && ref($count->{$ref}->{$bin}->{pair}) eq "ARRAY"){
         @pair = @{$count->{$ref}->{$bin}->{pair}};
@@ -1095,7 +1102,12 @@ if ($pval) {
         next if $dist eq "pair";
         next if $dist eq "rcount";
         next if $dist eq "pos";
-        $b_entropy = $count->{$ref}->{$bin}->{$dist}/$ri->{$ref}->{$bin}->{rcount}*log($count->{$ref}->{$bin}->{$dist}/$ri->{$ref}->{$bin}->{rcount}/$global_dist->{$dist});
+        my $prob = $count->{$ref}->{$bin}->{$dist}/$ri->{$ref}->{$bin}->{rcount};
+        my $exp_prob = $global_dist->{$dist};
+        $b_entropy = 0;
+        if ($prob > 0 && $exp_prob && $exp_prob > 0) {
+          $b_entropy = $prob * log($prob/$exp_prob);
+        }
         next if $b_entropy <= 0;
 
         # translocation

--- a/test_log_guards.pl
+++ b/test_log_guards.pl
@@ -1,0 +1,70 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+# Mocking modules before loading sv.pm
+BEGIN {
+    $INC{'Math/Round.pm'} = 1;
+    $INC{'Math/CDF.pm'} = 1;
+    $INC{'Math/Trig.pm'} = 1;
+    $INC{'Math/BigFloat.pm'} = 1;
+}
+
+# Provide mock implementations
+package Math::Round;
+sub round { return int($_[0] + 0.5); }
+package Math::CDF;
+sub pnorm { return 0.5; }
+package Math::Trig;
+use constant pi => 3.14159265358979;
+
+package sv;
+use constant pi => 3.14159265358979;
+
+package main;
+use lib '.';
+require sv;
+use Test::More tests => 5;
+
+# Test sv::ric with zero counts
+my $refh = { chr1 => 1000 };
+my $precount = { chr1 => { 100 => { 50 => 10, "pair" => [200] } } };
+my $global_dist = { 50 => 0 }; # Potential exp_prob = 0
+
+eval {
+    my ($ri, $count) = sv::ric($refh, $precount, 10, $global_dist);
+    ok(1, "sv::ric did not crash with exp_prob = 0");
+};
+if ($@) {
+    fail("sv::ric crashed: $@");
+}
+
+# Test sv::bootstrap with zero prob_dist
+my $prob_dist = { 50 => 0 };
+eval {
+    # We need to make sure bootstrap doesn't hang or crash.
+    # With prob_dist 0, CDF might be weird, but let's see if our guard in the loop works.
+    # Note: bootstrap might have other issues if prob_dist sums to 0, but we specifically fixed the log.
+    my $res = sv::bootstrap({50 => 0.1, 100 => 0}, 10, 5, 1);
+    ok(1, "sv::bootstrap did not crash with zero prob in distribution");
+};
+if ($@) {
+    fail("sv::bootstrap crashed: $@");
+}
+
+# Test sv::poissonApprox
+eval {
+    my $res = sv::poissonApprox(0, 10);
+    is($res, -1000, "sv::poissonApprox handles lambda=0");
+
+    $res = sv::poissonApprox(-1, 10);
+    is($res, -1000, "sv::poissonApprox handles lambda < 0");
+};
+
+# Test sv::factorialApprox
+eval {
+    my $res = sv::factorialApprox(undef);
+    is($res, 0, "sv::factorialApprox handles undef");
+};
+
+done_testing();


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerabilities in entropy calculations

### 🚨 Severity: MEDIUM
### 💡 Vulnerability:
The application was susceptible to runtime crashes (DoS) when calculating Relative Information Content (RIC) or bootstrapping if input data resulted in zero-valued probabilities or missing bins in the global distribution. In Perl, `log(0)` is a fatal error.

### 🎯 Impact:
A malicious or malformed BAM file could trigger these edge cases, causing the structural variation detection process to terminate unexpectedly.

### 🔧 Fix:
- Added guards to `sv::ric` and `sv::bootstrap` in `sv.pm` to skip zero-probability bins during entropy summation ($0 \log 0 = 0$ is mathematically correct here).
- Hardened `sv::poissonApprox` and `sv::factorialApprox` in `sv.pm` to handle zero or undefined inputs safely.
- Added a check in `svre.pl` to ensure at least one uniquely mapped paired-end read exists before proceeding with coverage calculations.
- Hardened output generation logic in `svre.pl` to prevent crashes when printing detailed statistics.

### ✅ Verification:
- Created `test_log_guards.pl` which mocks dependencies and verifies that the hardened functions no longer crash on edge case inputs.
- Ran existing security tests (`test_snr_security.pl`, `test_range_fix.pl`, `test_nan_dos.pl`, `test_ric_dos.pl`) to ensure no regressions.
- Verified syntax for both `sv.pm` and `svre.pl`.

---
*PR created automatically by Jules for task [100019853475031697](https://jules.google.com/task/100019853475031697) started by @swainechen*