### PR TITLE
🛡️ Sentinel: Fix Algorithmic Complexity DoS in sv::poisson

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -86,3 +86,8 @@
 **Vulnerability:** The `sv::null_distribution`, `sv::null_distribution_from_file`, `sv::rms_variance`, and `sv::refmod` functions were susceptible to infinite loops or division-by-zero crashes when provided with non-positive window sizes, reference lengths, or zero-valued bin counts.
 **Learning:** Utility functions in libraries often lack the strict validation present in the main application entry points. This can lead to vulnerabilities if the library is used by other tools or if validation is bypassed.
 **Prevention:** Implement strict guard clauses in all library functions that perform iterative calculations or division to ensure that divisors and loop increments (like `$ywin` or `$ref`) are strictly positive.
+
+## 2026-06-01 - Algorithmic Complexity DoS in Poisson Probability Calculation
+**Vulnerability:** The `sv::poisson` function used `Math::BigFloat`'s `bfac()` (factorial) and `bpow()` (power) methods, which exhibit $O(N)$ or worse complexity. For large inputs (e.g., $x=1,000,000$), this caused extreme CPU usage and process hangs, leading to a Denial of Service.
+**Learning:** Even when using arbitrary-precision libraries, certain operations like factorials can be computationally prohibitive. For statistical purposes, approximations (like Ramanujam's or Stirling's) often provide sufficient precision with $O(1)$ complexity.
+**Prevention:** Implement threshold-based logic in statistical functions to switch to efficient approximations for large input values. Always validate and bound inputs to prevent expensive operations from being triggered by untrusted data.

--- a/sv.pm
+++ b/sv.pm
@@ -263,6 +263,13 @@ sub normal {
 # Usage: poisson(rate, value)
 sub poisson {
   my ($success_rate, $x) = @_;
+  return 0 if $x < 0;
+
+  # Security: For large values, use poissonApprox to avoid expensive BigFloat operations (DoS)
+  if ($success_rate > 100 || $x > 100) {
+      return exp(sv::poissonApprox($success_rate, $x));
+  }
+
   my $y = Math::BigFloat->new(round($x));
   my $z = Math::BigFloat->new($success_rate);
 

--- a/test_log_guards.pl
+++ b/test_log_guards.pl
@@ -24,9 +24,24 @@ use constant pi => 3.14159265358979;
 package main;
 use lib '.';
 require sv;
-use Test::More tests => 5;
+use Test::More tests => 8;
 
-# Test sv::ric with zero counts
+# Test sv::poisson with hardened logic
+eval {
+    # Large inputs
+    my $start = time();
+    my $res = sv::poisson(10, 1000000);
+    my $end = time();
+    ok($end - $start < 1, "sv::poisson handles large x quickly");
+    is($res, 0, "sv::poisson(10, 1000000) returns 0");
+
+    # Negative inputs
+    $res = sv::poisson(2, -5);
+    is($res, 0, "sv::poisson handles negative x");
+};
+if ($@) {
+    diag("Error in sv::poisson tests: $@");
+}
 my $refh = { chr1 => 1000 };
 my $precount = { chr1 => { 100 => { 50 => 10, "pair" => [200] } } };
 my $global_dist = { 50 => 0 }; # Potential exp_prob = 0


### PR DESCRIPTION
The `sv::poisson` function in `sv.pm` was susceptible to a Denial of Service (DoS) attack due to its reliance on `Math::BigFloat`'s `bfac()` (factorial) and `bpow()` (power) methods for large inputs. These operations have $O(N)$ or worse complexity, leading to extreme CPU usage and process hangs for large values of $x$ or $\lambda$.

This change hardens the function by:
1.  **Using Approximations:** Switching to the $O(1)$ `sv::poissonApprox` (which uses Ramanujam's approximation) for inputs where $x > 100$ or $\lambda > 100$.
2.  **Input Validation:** Adding a guard to return 0 if $x < 0$, as Poisson probability is undefined for negative integers.
3.  **Regression Testing:** Integrating new test cases into `test_log_guards.pl` to verify that large inputs are handled instantly and negative inputs are correctly processed.
4.  **Documentation:** Recording the vulnerability and its prevention in `.jules/sentinel.md`.

This fix ensures the stability of the genomic statistical tools even when processing large or unexpected data points.

---
*PR created automatically by Jules for task [13158582212986489391](https://jules.google.com/task/13158582212986489391) started by @swainechen*