### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS via infinite loops in sv::createsv

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -91,3 +91,8 @@
 **Vulnerability:** The `sv::poisson` function used `Math::BigFloat`'s `bfac()` (factorial) and `bpow()` (power) methods, which exhibit $O(N)$ or worse complexity. For large inputs (e.g., $x=1,000,000$), this caused extreme CPU usage and process hangs, leading to a Denial of Service.
 **Learning:** Even when using arbitrary-precision libraries, certain operations like factorials can be computationally prohibitive. For statistical purposes, approximations (like Ramanujam's or Stirling's) often provide sufficient precision with $O(1)$ complexity.
 **Prevention:** Implement threshold-based logic in statistical functions to switch to efficient approximations for large input values. Always validate and bound inputs to prevent expensive operations from being triggered by untrusted data.
+
+## 2026-06-03 - Denial of Service via Infinite Loops in Structural Variation Selection
+**Vulnerability:** The `sv::createsv` subroutine used `while` loops with `redo` to find non-overlapping genomic positions for multiple structural variations. In cases where the genome was small or saturated with mutations, these loops could become infinite, leading to a Denial of Service (CPU exhaustion).
+**Learning:** "Trial and error" search algorithms for valid positions must have an upper bound on attempts. If a valid configuration cannot be found within a reasonable number of retries, it is safer to terminate with an error than to continue indefinitely.
+**Prevention:** Implement explicit retry counters and limits (e.g., 1000 attempts) for all iterative search loops that depend on random chance or data-driven constraints to satisfy overlap requirements.

--- a/sv.pm
+++ b/sv.pm
@@ -814,7 +814,9 @@ sub createsv{
   $position->{$pos} = $pos + $size;
   $position->{$pos2} = $pos2 + $size;
 
+  my $attempts = 0;
   CHECK: while( $check == 0 ){
+    die "Error: failed to find non-overlapping position for Deletion after 1000 attempts\n" if ++$attempts > 1000;
     ($seq, $pos, $size, $mutant) = deletion($parent, $read_length);
     foreach $p (keys %$position){
       if( $pos >= $p && $pos <= $position->{$p} ){
@@ -829,7 +831,9 @@ sub createsv{
   $position->{$pos} = $pos + $size;
 
   $check = 0;
+  $attempts = 0;
   CHECKa: while( $check == 0 ){
+    die "Error: failed to find non-overlapping position for Inversion after 1000 attempts\n" if ++$attempts > 1000;
     ($seq, $pos, $size, $mutant) = inversion($parent, $read_length);
     foreach $p (keys %$position){
       if( $pos >= $p && $pos <= $position->{$p} ){
@@ -844,7 +848,9 @@ sub createsv{
   $position->{$pos} = $pos + $size;
 
   $check = 0;
+  $attempts = 0;
   CHECKb: while( $check == 0 ){
+    die "Error: failed to find non-overlapping position for Tandem after 1000 attempts\n" if ++$attempts > 1000;
     ($seq, $pos, $pos2, $size, $mutant) = tandem($parent, $read_length);
     foreach $p (keys %$position){
       if( $pos >= $p && $pos <= $position->{$p} ){
@@ -863,7 +869,9 @@ sub createsv{
   $position->{$pos} = $pos + $size;
 
   $check = 0;
+  $attempts = 0;
   CHECKc: while( $check == 0 ){
+    die "Error: failed to find non-overlapping position for Insertion after 1000 attempts\n" if ++$attempts > 1000;
     ($seq, $pos, $size, $mutant) = insertion($parent, $read_length);
     foreach $p (keys %$position){
       if( $pos >= $p && $pos <= $position->{$p} ){


### PR DESCRIPTION
This PR fixes a Denial of Service (DoS) vulnerability in the `sv::createsv` function within `sv.pm`. 

The function used several `while` loops with `redo` to find non-overlapping genomic positions for different types of structural variations (Deletion, Inversion, Tandem, Insertion). These loops relied on random selection and could become infinite if the constraints (non-overlapping with previous mutations) were impossible or very difficult to satisfy.

The fix introduces an explicit `$attempts` counter and a limit of 1000 iterations for each of these loops. If the limit is reached, the function calls `die` with an informative error message, preventing CPU exhaustion.

Changes:
- Added retry limits to four loops in `sv::createsv` in `sv.pm`.
- Updated `.jules/sentinel.md` with a new security learning entry.
- Verified with a reproduction script that specifically triggers the infinite loop condition.
- Verified no regressions in other `sv.pm` functions using existing security test scripts.

---
*PR created automatically by Jules for task [828610956809924363](https://jules.google.com/task/828610956809924363) started by @swainechen*