### PR TITLE
🛡️ Sentinel: Fix division-by-zero DoS in RIC calculations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -110,3 +110,8 @@
 **Prevention:**
 1. Always guard division operations in reporting logic with checks for non-zero denominators, especially when the divisor is an aggregate sum of data-dependent values like entropy.
 2. Implement strict input validation (`defined` and `isfloat` checks) at the beginning of library subroutines to ensure they fail gracefully when provided with invalid data.
+
+## 2026-06-10 - Denial of Service via Division-by-Zero in rcount processing
+**Vulnerability:** The application crashed (DoS) when calculating probability distributions in genomic bins that contained only translocations, resulting in a standard read count (`rcount`) of zero.
+**Learning:** Genomic bins can have zero standard reads if they only contain translocation data (stored under the "pair" key). Binning logic must not assume `rcount > 0` even if the bin exists in the data structure.
+**Prevention:** Explicitly guard all divisions using `rcount` as a divisor in `sv::ric` and output generation loops.

--- a/sv.pm
+++ b/sv.pm
@@ -1147,7 +1147,9 @@ sub ric {
         next if $dist eq "pos";
         my $info_w = 0;
         $prob = 0;
-        $prob = $count->{$ref}->{$bin}->{$dist}/$rcount;
+        if ($rcount > 0) {
+          $prob = $count->{$ref}->{$bin}->{$dist}/$rcount;
+        }
         $exp_prob = $global_dist->{$dist};
 
         if ($prob > 0 && $exp_prob && $exp_prob > 0) {

--- a/svre.pl
+++ b/svre.pl
@@ -929,7 +929,7 @@ foreach $ref (@refnames) {
         next if $dist eq "pair";
         next if $dist eq "rcount";
         next if $dist eq "pos";
-        my $prob = $count->{$ref}->{$bin}->{$dist}/$ri->{$ref}->{$bin}->{rcount};
+        my $prob = ($ri->{$ref}->{$bin}->{rcount} > 0) ? $count->{$ref}->{$bin}->{$dist}/$ri->{$ref}->{$bin}->{rcount} : 0;
         my $exp_prob = $global_dist->{$dist};
         my $info_w = 0;
         if ($prob > 0 && $exp_prob && $exp_prob > 0) {
@@ -1106,7 +1106,7 @@ if ($pval) {
         next if $dist eq "pair";
         next if $dist eq "rcount";
         next if $dist eq "pos";
-        my $prob = $count->{$ref}->{$bin}->{$dist}/$ri->{$ref}->{$bin}->{rcount};
+        my $prob = ($ri->{$ref}->{$bin}->{rcount} > 0) ? $count->{$ref}->{$bin}->{$dist}/$ri->{$ref}->{$bin}->{rcount} : 0;
         my $exp_prob = $global_dist->{$dist};
         $b_entropy = 0;
         if ($prob > 0 && $exp_prob && $exp_prob > 0) {


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Fix division-by-zero DoS in RIC calculations

#### 🚨 Severity: HIGH
#### 💡 Vulnerability:
The application was susceptible to a Denial of Service (DoS) crash due to division-by-zero when processing genomic bins that contain only translocations. In such cases, the `rcount` (the number of uniquely mapped reads used for entropy calculation) is 0.

#### 🎯 Impact:
A malicious or malformed BAM file could trigger this condition, causing the `svre.pl` script to terminate prematurely, preventing structural variation analysis.

#### 🔧 Fix:
Added explicit `rcount > 0` checks before every division using `rcount` as a divisor in:
- `sv::ric` subroutine in `sv.pm`
- RIC reporting loop in `svre.pl`
- SV typing loop in `svre.pl`

#### ✅ Verification:
- Created a reproduction script that mocks a zero-rcount bin and verified it no longer crashes.
- Ran `test_ric_dos.pl` and `test_nan_dos.pl` to ensure no regressions in performance or stability.
- Verified syntax for both `sv.pm` and `svre.pl` using `perl -c`.
- Cleaned up all temporary test files.

---
*PR created automatically by Jules for task [2959472501401687921](https://jules.google.com/task/2959472501401687921) started by @swainechen*