### PR TITLE
🛡️ Sentinel: Harden average and stdev subroutines against DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -115,3 +115,8 @@
 **Vulnerability:** The application crashed (DoS) when calculating probability distributions in genomic bins that contained only translocations, resulting in a standard read count (`rcount`) of zero.
 **Learning:** Genomic bins can have zero standard reads if they only contain translocation data (stored under the "pair" key). Binning logic must not assume `rcount > 0` even if the bin exists in the data structure.
 **Prevention:** Explicitly guard all divisions using `rcount` as a divisor in `sv::ric` and output generation loops.
+
+## 2026-06-12 - Denial of Service via Missing Input Validation in Utility Functions
+**Vulnerability:** The `sv::average` and `sv::stdev` subroutines in `sv.pm` were susceptible to script termination (DoS) when provided with empty arrays (via `die`) or non-numeric data (via fatal warnings/errors during arithmetic).
+**Learning:** General-purpose utility functions in shared modules often lack the strict validation found in main entry points. When these utilities are used on data derived from untrusted or sparse genomic sources, they can cause unexpected application failure.
+**Prevention:** Always harden utility functions that perform arithmetic or statistical operations. Filter input data for numeric types using `isfloat` or `looks_like_number` and return safe defaults (e.g., 0) instead of using `die` for empty input sets.

--- a/sv.pm
+++ b/sv.pm
@@ -927,31 +927,21 @@ sub createsv{
 }
 
 # average and stdev from http://edwards.sdsu.edu/research/index.php/kate/302-calculating-the-average-and-standard-deviation
+# Both functions are hardened against non-numeric data and empty arrays to prevent DoS (crashes).
 sub average {
-  my($data) = @_;
-  if (not @$data) {
-    die("Empty array\n");
-  }
-  my $total = 0;
-  foreach (@$data) {
-    $total += $_;
-  }
-  my $average = $total / @$data;
-  return $average;
+  my ($data) = @_;
+  my @filtered = grep { isfloat($_) } @$data;
+  return 0 unless @filtered;
+  return sum(@filtered) / scalar(@filtered);
 }
 
 sub stdev {
   my ($data) = @_;
-  if (@$data == 1) {
-    return 0;
-  }
-  my $average = &average($data);
-  my $sqtotal = 0;
-  foreach(@$data) {
-    $sqtotal += ($average-$_) ** 2;
-  }
-  my $std = ($sqtotal / (@$data-1)) ** 0.5;
-  return $std;
+  my @filtered = grep { isfloat($_) } @$data;
+  my $n = scalar(@filtered);
+  return 0 if $n < 2;
+  my $avg = sum(@filtered) / $n;
+  return (sum(map { ($_ - $avg) ** 2 } @filtered) / ($n - 1)) ** 0.5;
 }
 
 sub array_median {


### PR DESCRIPTION
🛡️ Sentinel: Harden average and stdev subroutines against DoS

Hardened the `sv::average` and `sv::stdev` subroutines in `sv.pm` to prevent
application crashes (Denial of Service) when processing malformed or empty
data.

Changes:
- Added numeric filtering using `isfloat` to both functions.
- Modified `average` to return 0 instead of calling `die` on empty arrays.
- Modified `stdev` to return 0 for arrays with fewer than two numeric elements.
- Optimized both functions to use `sum` and `map` for better readability
  and efficiency.
- Updated `.jules/sentinel.md` with the new learning.

This fix ensures that the application remains available even when
presented with sparse or invalid genomic datasets.

---
*PR created automatically by Jules for task [213083504714365917](https://jules.google.com/task/213083504714365917) started by @swainechen*