### PR TITLE
🛡️ Sentinel: Harden CLI numeric validation against NaN bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -120,3 +120,8 @@
 **Vulnerability:** The `sv::average` and `sv::stdev` subroutines in `sv.pm` were susceptible to script termination (DoS) when provided with empty arrays (via `die`) or non-numeric data (via fatal warnings/errors during arithmetic).
 **Learning:** General-purpose utility functions in shared modules often lack the strict validation found in main entry points. When these utilities are used on data derived from untrusted or sparse genomic sources, they can cause unexpected application failure.
 **Prevention:** Always harden utility functions that perform arithmetic or statistical operations. Filter input data for numeric types using `isfloat` or `looks_like_number` and return safe defaults (e.g., 0) instead of using `die` for empty input sets.
+
+## 2026-06-14 - Bypass of Numeric Range Checks via NaN/Inf in Command-Line Arguments
+**Vulnerability:** Command-line arguments (`bootstrap`, `fdr`, `ywindow`, `cov`, `mapq`) were vulnerable to `NaN` or `Inf` values bypassing numeric range checks. For example, `NaN <= 0` and `NaN > 100` both evaluate to false in Perl, allowing `NaN` to pass a `die "Error" if $x <= 0 or $x > 100` check.
+**Learning:** In Perl, numeric comparisons with `NaN` always return false. This can lead to security bypasses if the application assumes that failing a range check implies the value is valid.
+**Prevention:** Always validate that a numeric string is a valid number using a helper like `sv::isfloat()` (which uses a strict regex) before performing numeric range comparisons.

--- a/svre.pl
+++ b/svre.pl
@@ -165,11 +165,11 @@ GetOptions(
 ) or die "Error parsing command line options\n";
 
 # Security: Validate user-provided and calculated parameters to prevent resource exhaustion and division-by-zero
-die "Error: bootstrap must be between 1 and 100,000,000\n" if $bootstrap <= 0 or $bootstrap > 100000000;
-die "Error: fdr must be between 0 and 1\n" if $fdr <= 0 or $fdr >= 1;
-die "Error: ywindow must be greater than or equal to 0\n" if $ywin < 0;
-die "Error: cov must be between 1 and 1,000,000\n" if $cov_bin <= 0 or $cov_bin > 1000000;
-die "Error: mapq must be non-negative\n" if $mapq_min < 0;
+die "Error: bootstrap must be a valid number between 1 and 100,000,000\n" if !sv::isfloat($bootstrap) or $bootstrap <= 0 or $bootstrap > 100000000;
+die "Error: fdr must be a valid number between 0 and 1\n" if !sv::isfloat($fdr) or $fdr <= 0 or $fdr >= 1;
+die "Error: ywindow must be a valid non-negative number\n" if !sv::isfloat($ywin) or $ywin < 0;
+die "Error: cov must be a valid number between 1 and 1,000,000\n" if !sv::isfloat($cov_bin) or $cov_bin <= 0 or $cov_bin > 1000000;
+die "Error: mapq must be a valid non-negative number\n" if !sv::isfloat($mapq_min) or $mapq_min < 0;
 
 if ($samtools_command eq '') {
     die "Error: samtools not found in PATH. Please install samtools.\n";


### PR DESCRIPTION
This PR hardens the command-line argument validation in `svre.pl`. 

In Perl, numeric comparisons with `NaN` (Not-a-Number) always return false. This meant that range checks like `die if $x <= 0 or $x > 100` could be bypassed by passing `nan`, because `nan <= 0` is false and `nan > 100` is false.

I have updated the validation logic for the following parameters:
- `bootstrap`
- `fdr`
- `ywindow` (via `ywin`)
- `cov` (via `cov_bin`)
- `mapq` (via `mapq_min`)

The fix uses the existing `sv::isfloat()` helper function to ensure the input is a valid numeric string before performing the range comparisons.

Verification was performed by mocking the environment and dependencies in a restricted shell, confirming that out-of-range and invalid numeric inputs are correctly rejected with descriptive error messages.

---
*PR created automatically by Jules for task [8592454561677145652](https://jules.google.com/task/8592454561677145652) started by @swainechen*