### PR TITLE
🛡️ Sentinel: Fix logic bug causing data loss in structural variation reporting

### DIFF
--- a/svre.pl
+++ b/svre.pl
@@ -1246,13 +1246,17 @@ if ($pval) {
             } else {
               push @out, sprintf("%s:%s(%.2f)", $key, $r[0], $j);
               $merge_sv->{$merge_i}->{bp1}->{ref} = $ref;
-              $merge_sv->{$merge_i}->{bp2}->{ref} = $f[$i];	# this should be \d+___ref
-              $merge_sv->{$merge_i}->{bp2}->{ref} =~ s/\d+___//;
+              # Fix: Use the correct reference from the group being reported
+              $merge_sv->{$merge_i}->{bp2}->{ref} = $r[0];
+              $merge_sv->{$merge_i}->{bp2}->{ref} =~ s/^-?\d+(\.\.\d+)?___//;
               $merge_sv->{$merge_i}->{bp1}->{coord} = abs($bin) . ".." . (abs($bin) + $ri->{$ref}->{$bin}->{binsize} + 1);	# to make sure we overlap later with the next bin
               $merge_sv->{$merge_i}->{bp2}->{coord} = sv::absrange(\@r, $range_cluster);
             }
           }
-          $j = 0;
+          # Fix: Correctly initialize variables for the next group using current element
+          $j = ($pos_e != 0) ? $sv->{$f[$i]}->{entropy}/$pos_e : 0;
+          $key = $sv->{$f[$i]}->{type};
+          @r = ($sv->{$f[$i]}->{target});
         }
       }
       if ($j > $fdr) {
@@ -1268,8 +1272,9 @@ if ($pval) {
         } else {		# a translocation
           push @out, sprintf("%s:%s(%.2f)", $key, $r[0], $j);
           $merge_sv->{$merge_i}->{bp1}->{ref} = $ref;
-          $merge_sv->{$merge_i}->{bp2}->{ref} = $f[$#f];	# this should be \d+___ref
-          $merge_sv->{$merge_i}->{bp2}->{ref} =~ s/\d+___//;
+          # Fix: Use the correct reference from the group being reported
+          $merge_sv->{$merge_i}->{bp2}->{ref} = $r[0];
+          $merge_sv->{$merge_i}->{bp2}->{ref} =~ s/^-?\d+(\.\.\d+)?___//;
           $merge_sv->{$merge_i}->{bp1}->{coord} = abs($bin) . ".." . (abs($bin) + $ri->{$ref}->{$bin}->{binsize} + 1);	# to make sure we overlap later with the next bin
           $merge_sv->{$merge_i}->{bp2}->{coord} = sv::absrange(\@r, $range_cluster);
         }


### PR DESCRIPTION
This PR fixes a critical logic bug in the structural variation (SV) reporting module of `svre.pl`. 

### 💡 Vulnerability: Data Loss in SV Reporting
The merging loop responsible for grouping significant genomic bins into structural variations had a logic error where any bin that triggered a transition (e.g., a change in SV type or a large coordinate gap) was discarded. This meant that if multiple different SVs were detected in the same bin, or if a new SV started immediately after another, the first bin of the subsequent SV would be lost. In some cases, this could lead to the entire SV being unreported if it consisted of only one or two bins.

### 🎯 Impact: Integrity/Detection Bypass
Structural variations that are statistically significant could be omitted from the final output (`_SV.txt`). This directly impacts the tool's primary purpose and could allow significant genomic events to go unnoticed by the user.

### 🔧 Fix
1.  **State Re-initialization:** Updated the loop's `else` block to correctly re-initialize the merging state (`$j`, `$key`, `@r`) with the current element's data after closing the previous group.
2.  **Robust Metadata Extraction:** Improved the extraction of target references for translocations by using the specific target data from the group being reported and utilizing a more robust regex that handles negative coordinates and ranges.
3.  **Defensive Coding:** Added a check to prevent division by zero when calculating entropy proportions.

### ✅ Verification
- Created a reproduction script `test_sv_reporting.pl` that simulated the vulnerable loop with mock data. Confirmed that the original code lost an inversion and a translocation, while the fixed code correctly reported all variations with accurate metadata.
- Ran the full suite of existing tests (`test_*.pl`) and verified no regressions were introduced.
- Verified that translocation target references (e.g., `chr2`) are now correctly extracted even from complex range strings.

---
*PR created automatically by Jules for task [5246712170558136968](https://jules.google.com/task/5246712170558136968) started by @swainechen*