### PR TITLE
🛡️ Sentinel: Fix metadata corruption in svre.pl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -126,6 +126,11 @@
 **Learning:** In Perl, numeric comparisons with `NaN` always return false. This can lead to security bypasses if the application assumes that failing a range check implies the value is valid.
 **Prevention:** Always validate that a numeric string is a valid number using a helper like `sv::isfloat()` (which uses a strict regex) before performing numeric range comparisons.
 
+## 2025-06-20 - Metadata Corruption via Negative Coordinate Ranges
+**Vulnerability:** Regex-based metadata extraction failed to handle negative numbers in genomic ranges, leading to coordinate data leaking into reference name variables.
+**Learning:** In bioinformatics, coordinates can be negative (e.g., relative to a feature or on the reverse strand). Sanitization regexes must explicitly account for optional signs in all numeric parts of a range.
+**Prevention:** Use robust regexes like `s/^-?\d+(\.\.-?\d+)?___//` when stripping coordinate prefixes that might contain negative values.
+
 ## 2026-06-16 - Algorithmic Complexity DoS in sv::bootstrap
 **Vulnerability:** The `sv::bootstrap` function in `sv.pm` was susceptible to an Algorithmic Complexity DoS. For each bootstrapping iteration, it performed a linear scan of a slice of the Cumulative Distribution Function (CDF) array to map random samples to bins. When processing datasets with a large number of bins (e.g., 1,000,000), this led to $O(N)$ complexity per sample, causing extreme CPU usage and multi-minute execution times.
 **Learning:** Sampling from a large discrete distribution using a linear CDF sweep is a common performance bottleneck and security risk. Sorting samples and sweeping can help, but direct binary search into the CDF is more robust and efficient for independent samples.

--- a/svre.pl
+++ b/svre.pl
@@ -1246,9 +1246,10 @@ if ($pval) {
             } else {
               push @out, sprintf("%s:%s(%.2f)", $key, $r[0], $j);
               $merge_sv->{$merge_i}->{bp1}->{ref} = $ref;
-              # Fix: Use the correct reference from the group being reported
+              # Fix: Use the correct reference from the group being reported.
+              # Security: Robustly strip metadata prefix to prevent variable contamination.
               $merge_sv->{$merge_i}->{bp2}->{ref} = $r[0];
-              $merge_sv->{$merge_i}->{bp2}->{ref} =~ s/^-?\d+(\.\.\d+)?___//;
+              $merge_sv->{$merge_i}->{bp2}->{ref} =~ s/^-?\d+(\.\.-?\d+)?___//;
               $merge_sv->{$merge_i}->{bp1}->{coord} = abs($bin) . ".." . (abs($bin) + $ri->{$ref}->{$bin}->{binsize} + 1);	# to make sure we overlap later with the next bin
               $merge_sv->{$merge_i}->{bp2}->{coord} = sv::absrange(\@r, $range_cluster);
             }
@@ -1272,9 +1273,10 @@ if ($pval) {
         } else {		# a translocation
           push @out, sprintf("%s:%s(%.2f)", $key, $r[0], $j);
           $merge_sv->{$merge_i}->{bp1}->{ref} = $ref;
-          # Fix: Use the correct reference from the group being reported
+          # Fix: Use the correct reference from the group being reported.
+          # Security: Robustly strip metadata prefix to prevent variable contamination.
           $merge_sv->{$merge_i}->{bp2}->{ref} = $r[0];
-          $merge_sv->{$merge_i}->{bp2}->{ref} =~ s/^-?\d+(\.\.\d+)?___//;
+          $merge_sv->{$merge_i}->{bp2}->{ref} =~ s/^-?\d+(\.\.-?\d+)?___//;
           $merge_sv->{$merge_i}->{bp1}->{coord} = abs($bin) . ".." . (abs($bin) + $ri->{$ref}->{$bin}->{binsize} + 1);	# to make sure we overlap later with the next bin
           $merge_sv->{$merge_i}->{bp2}->{coord} = sv::absrange(\@r, $range_cluster);
         }


### PR DESCRIPTION
🛡️ Sentinel: Fix metadata corruption via robust coordinate range stripping

🚨 Severity: MEDIUM
💡 Vulnerability: Regex-based metadata extraction failed to handle negative numbers in genomic ranges (e.g., `-200..-100___chr1`).
🎯 Impact: Coordinate data leaks into reference name variables, potentially leading to downstream logic failures or incorrect SV reporting.
🔧 Fix: Updated the stripping regex to `s/^-?\d+(\.\.-?\d+)?___//` to account for optional negative signs in both ends of the range.
✅ Verification: Verified with `test_regex_fix.pl` (created and deleted during task) and ensured no regressions in existing `test_*.pl` suite.

---
*PR created automatically by Jules for task [673023996517337414](https://jules.google.com/task/673023996517337414) started by @swainechen*