### PR TITLE
🛡️ Sentinel: Fix Path Traversal in -output parameter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -148,3 +148,8 @@
 1. Implement strict definedness checks at the beginning of utility functions that accept optional or data-dependent parameters.
 2. Ensure that filtering logic for sorting (e.g., creating `@defined` lists) correctly excludes `undef` values to prevent sorting errors.
 3. Follow idiomatic coding standards for the language; in Perl, avoid redundant package prefixes for internal calls within the same namespace.
+
+## 2026-06-21 - Path Traversal via Output Filenames
+**Vulnerability:** User-provided output filename prefixes were susceptible to path traversal via `..` components, allowing arbitrary file writes outside the intended output directory.
+**Learning:** `File::Spec->rel2abs()` resolves relative paths to absolute ones but preserves `..` components. If these absolute paths containing `..` are used in file operations or passed to external tools (like `Rscript`), they can still be exploited for path traversal.
+**Prevention:** Use `File::Spec->canonpath()` to normalize the path and explicitly check for `..` components (e.g., using regex `/\.\.(\/|\\|$)/`) before proceeding with file operations.

--- a/svre.pl
+++ b/svre.pl
@@ -203,6 +203,12 @@ if ($r1 ne "" && -f $r1 && $r2 ne "" && -f $r2) {
   die "Error: Invalid character in r1 path\n" if $r1 =~ /\0/;
   die "Error: Invalid character in r2 path\n" if $r2 =~ /\0/;
   die "Error: Invalid character in output name\n" if $output =~ /\0/;
+
+  # Security: Prevent path traversal in output name
+  if (File::Spec->canonpath($output) =~ /\.\.(\/|\\|$)/) {
+    die "Error: Path traversal attempt detected in output name\n";
+  }
+
   $output = File::Spec->rel2abs($output);
 } else {
   print <<__USAGE__;


### PR DESCRIPTION
I identified a path traversal vulnerability in `svre.pl` where the `-output` parameter could be used to write files outside of the intended directory by using `..` components. Although the script used `File::Spec->rel2abs()`, this does not actually remove `..` segments.

I have hardened the input validation for the `-output` parameter by:
1. Normalizing the path using `File::Spec->canonpath()`.
2. Checking for any `..` components in the normalized path and terminating with an error if found.

I verified this fix by creating a reproduction script that confirms `..` is now blocked while valid paths are still accepted. I also ran the existing validation tests to ensure no regressions.

---
*PR created automatically by Jules for task [5312279325728931225](https://jules.google.com/task/5312279325728931225) started by @swainechen*