### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix SSRF and harden SAM tag validation

### DIFF
--- a/svre.pl
+++ b/svre.pl
@@ -214,6 +214,11 @@ if ($r1 ne "" && -f $r1 && $r2 ne "" && -f $r2) {
     die "Error: Output prefix cannot start with a pipe character\n";
   }
 
+  # Security: Mitigate SSRF in R's read.table/plot
+  if ($output =~ /:\/\//) {
+    die "Error: Output prefix cannot contain a protocol (://)\n";
+  }
+
   $output = File::Spec->rel2abs($output);
 } else {
   print <<__USAGE__;
@@ -390,24 +395,24 @@ if (-B $r1) {
 while (<$rh1>) {
 #  if ($mapper eq "bwa" && $mapper_version =~ /^0\.7\.10/) {
   if ($mapper eq "bwa" && $mapper_command_line =~ /bwa\s+mem/) {
-    next if $_ !~ /NM\:i\:0/;
-    next if $_ !~ /XS\:i\:0/;
+    next if $_ !~ /\tNM:i:0(\t|\r?\n|$)/;
+    next if $_ !~ /\tXS:i:0(\t|\r?\n|$)/;
 #  } elsif ($mapper eq "bwa") {
   } elsif ($mapper eq "bwa" && $mapper_command_line =~ /bwa\s+sam[ps]e/) {
-    next if $_ !~ /XT\:A\:U/;
-    next if $_ !~ /NM\:i\:0/;
-    next if $_ !~ /XM\:i\:0/;
-    next if $_ !~ /X0\:i\:1/;
+    next if $_ !~ /\tXT:A:U(\t|\r?\n|$)/;
+    next if $_ !~ /\tNM:i:0(\t|\r?\n|$)/;
+    next if $_ !~ /\tXM:i:0(\t|\r?\n|$)/;
+    next if $_ !~ /\tX0:i:1(\t|\r?\n|$)/;
   } elsif ($mapper eq "Bowtie" || $mapper eq "bowtie") {
-    next if $_ !~ /XA\:i\:0/;
-    next if $_ !~ /NM\:i\:0/;
+    next if $_ !~ /\tXA:i:0(\t|\r?\n|$)/;
+    next if $_ !~ /\tNM:i:0(\t|\r?\n|$)/;
   } elsif ($mapper eq "Bowtie2" || $mapper eq "bowtie2") {
-    next if $_ !~ /XM\:i\:0/;
-    next if $_ !~ /XG\:i\:0/;
-    next if $_ !~ /XO\:i\:0/;
-    next if $_ !~ /NM\:i\:0/;
+    next if $_ !~ /\tXM:i:0(\t|\r?\n|$)/;
+    next if $_ !~ /\tXG:i:0(\t|\r?\n|$)/;
+    next if $_ !~ /\tXO:i:0(\t|\r?\n|$)/;
+    next if $_ !~ /\tNM:i:0(\t|\r?\n|$)/;
   } else {
-    next if $_ !~ /NM\:i\:0/;
+    next if $_ !~ /\tNM:i:0(\t|\r?\n|$)/;
   }
   @f = split /\t/, $_;
   # sam flag 4 is unmapped, 16 is reverse strand map for the read
@@ -434,24 +439,24 @@ if (-B $r2) {
 while (<$rh2>){
 #  if ($mapper eq "bwa" && $mapper_version =~ /^0\.7\.10/) {
   if ($mapper eq "bwa" && $mapper_command_line =~ /bwa\s+mem/) {
-    next if $_ !~ /NM\:i\:0/;
-    next if $_ !~ /XS\:i\:0/;
+    next if $_ !~ /\tNM:i:0(\t|\r?\n|$)/;
+    next if $_ !~ /\tXS:i:0(\t|\r?\n|$)/;
 #  } elsif ($mapper eq "bwa") {
   } elsif ($mapper eq "bwa" && $mapper_command_line =~ /bwa\s+sam[ps]e/) {
-    next if $_ !~ /XT\:A\:U/;
-    next if $_ !~ /NM\:i\:0/;
-    next if $_ !~ /XM\:i\:0/;
-    next if $_ !~ /X0\:i\:1/;
+    next if $_ !~ /\tXT:A:U(\t|\r?\n|$)/;
+    next if $_ !~ /\tNM:i:0(\t|\r?\n|$)/;
+    next if $_ !~ /\tXM:i:0(\t|\r?\n|$)/;
+    next if $_ !~ /\tX0:i:1(\t|\r?\n|$)/;
   } elsif ($mapper eq "Bowtie" || $mapper eq "bowtie") {
-    next if $_ !~ /XA\:i\:0/;
-    next if $_ !~ /NM\:i\:0/;
+    next if $_ !~ /\tXA:i:0(\t|\r?\n|$)/;
+    next if $_ !~ /\tNM:i:0(\t|\r?\n|$)/;
   } elsif ($mapper eq "Bowtie2" || $mapper eq "bowtie2") {
-    next if $_ !~ /XM\:i\:0/;
-    next if $_ !~ /XG\:i\:0/;
-    next if $_ !~ /XO\:i\:0/;
-    next if $_ !~ /NM\:i\:0/;
+    next if $_ !~ /\tXM:i:0(\t|\r?\n|$)/;
+    next if $_ !~ /\tXG:i:0(\t|\r?\n|$)/;
+    next if $_ !~ /\tXO:i:0(\t|\r?\n|$)/;
+    next if $_ !~ /\tNM:i:0(\t|\r?\n|$)/;
   } else {
-    next if $_ !~ /NM\:i\:0/;
+    next if $_ !~ /\tNM:i:0(\t|\r?\n|$)/;
   }
   @f = split /\t/, $_;
   next if $f[1] & 4;

--- a/test_sam_regex.pl
+++ b/test_sam_regex.pl
@@ -1,0 +1,51 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 5;
+
+# This script verifies that the updated regexes in svre.pl correctly
+# distinguish between SAM tags and spoofed tags in the read name,
+# including support for CRLF line endings.
+
+my @test_regexes = (
+    qr/\tNM:i:0(\t|\r?\n|$)/,
+    qr/\tXS:i:0(\t|\r?\n|$)/,
+    qr/\tXT:A:U(\t|\r?\n|$)/,
+);
+
+subtest 'Positive matches (Valid SAM lines)' => sub {
+    plan tests => 3;
+    my $good_line = "read1\t0\tchr1\t100\t60\t75M\t*\t0\t0\tSEQ\tQUAL\tNM:i:0\tXS:i:0\tXT:A:U\n";
+    ok($good_line =~ $test_regexes[0], "NM:i:0 matches in good line");
+    ok($good_line =~ $test_regexes[1], "XS:i:0 matches in good line");
+    ok($good_line =~ $test_regexes[2], "XT:A:U matches in good line");
+};
+
+subtest 'CRLF support' => sub {
+    plan tests => 1;
+    my $crlf_line = "read1\t0\tchr1\t100\t60\t75M\t*\t0\t0\tSEQ\tQUAL\tNM:i:0\r\n";
+    ok($crlf_line =~ $test_regexes[0], "NM:i:0 matches with CRLF line ending");
+};
+
+subtest 'Negative matches (Spoofed in read name)' => sub {
+    plan tests => 3;
+    my $bad_line = "read_NM:i:0_XS:i:0_XT:A:U\t0\tchr1\t100\t60\t75M\t*\t0\t0\tSEQ\tQUAL\tNM:i:5\n";
+    ok($bad_line !~ $test_regexes[0], "NM:i:0 does NOT match in bad line");
+    ok($bad_line !~ $test_regexes[1], "XS:i:0 does NOT match in bad line");
+    ok($bad_line !~ $test_regexes[2], "XT:A:U does NOT match in bad line");
+};
+
+subtest 'Negative matches (Partial tag match)' => sub {
+    plan tests => 2;
+    my $partial_line = "read1\t0\tchr1\t100\t60\t75M\t*\t0\t0\tSEQ\tQUAL\tNM:i:00\tXS:i:0.5\n";
+    ok($partial_line !~ $test_regexes[0], "NM:i:00 does NOT match NM:i:0");
+    ok($partial_line !~ $test_regexes[1], "XS:i:0.5 does NOT match XS:i:0");
+};
+
+subtest 'End of line matches' => sub {
+    plan tests => 1;
+    my $eol_line = "read1\t0\tchr1\t100\t60\t75M\t*\t0\t0\tSEQ\tQUAL\tNM:i:0";
+    ok($eol_line =~ $test_regexes[0], "NM:i:0 matches at end of string without newline");
+};
+
+done_testing();


### PR DESCRIPTION
This PR addresses two security concerns in `svre.pl`:

1. **Critical SSRF Protection**: The `-output` parameter is used to construct filenames that are passed to R scripts. R's `read.table` and other functions can treat URLs as valid inputs, potentially leading to Server-Side Request Forgery (SSRF). An explicit check has been added to forbid any protocols (`://`) in the output prefix.
2. **Robust SAM Tag Validation**: Identity and uniqueness filters in the SAM parsing loops previously used loose regular expressions (e.g., `/NM:i:0/`). This allowed an attacker to bypass filters by including spoofed tags in the read name field of a SAM line. The regexes are now anchored by tabs and handle both LF and CRLF line endings (e.g., `/\tNM:i:0(\t|\r?\n|$)/`).

Changes were verified with a new test suite (`test_sam_regex.pl`) and by running all existing regression tests.

---
*PR created automatically by Jules for task [8301424438065982170](https://jules.google.com/task/8301424438065982170) started by @swainechen*