### PR TITLE
🛡️ Sentinel: Fix log injection, SSRF, and parameter validation

### DIFF
--- a/svre.pl
+++ b/svre.pl
@@ -30,6 +30,8 @@ use File::Spec;
 #@@@@@@@@@@@
 my $tempdir = File::Spec->rel2abs(File::Temp::tempdir("svre_XXXXXXXX", TMPDIR => 1, CLEANUP => 1));
 my $command_line = join (" ", $0, @ARGV); chomp $command_line;
+# Security: Sanitize command line for logging to prevent log injection
+$command_line =~ s/[\r\n]/ /g;
 my $read;	# the main data file
 my $r1 = "";	# sam/bam file 1
 my $r2 = "";	# sam/bam file 2
@@ -171,6 +173,10 @@ die "Error: ywindow must be a valid non-negative number\n" if !sv::isfloat($ywin
 die "Error: cov must be a valid number between 1 and 1,000,000\n" if !sv::isfloat($cov_bin) or $cov_bin <= 0 or $cov_bin > 1000000;
 die "Error: mapq must be a valid non-negative number\n" if !sv::isfloat($mapq_min) or $mapq_min < 0;
 
+# Security: Validate additional parameters
+die "Error: ori must be either FR or FF\n" if $ori ne "FR" and $ori ne "FF";
+die "Error: range must be a valid non-negative number\n" if !sv::isfloat($range_cluster) or $range_cluster < 0;
+
 if ($samtools_command eq '') {
     die "Error: samtools not found in PATH. Please install samtools.\n";
 }
@@ -212,6 +218,11 @@ if ($r1 ne "" && -f $r1 && $r2 ne "" && -f $r2) {
   # Security: Mitigate R command injection via read.table pipes
   if ($output =~ /^\s*\|/) {
     die "Error: Output prefix cannot start with a pipe character\n";
+  }
+
+  # Security: Prevent SSRF in R by blocking protocol strings in output path
+  if ($output =~ /:\/\//) {
+    die "Error: Output prefix cannot contain a protocol string (://)\n";
   }
 
   $output = File::Spec->rel2abs($output);


### PR DESCRIPTION
🚨 Severity: MEDIUM/HIGH

💡 Vulnerability:
- Log injection in `svre.pl` via un-sanitized `$command_line` being printed directly to the detail log file.
- SSRF risk where the `-output` parameter could be used to pass URLs to R's `read.table` or `plot` functions.
- Missing validation for the `-ori` (orientation) and `-range` parameters.

🎯 Impact:
- Attackers could inject false or misleading entries into the analysis logs.
- Potential for Server-Side Request Forgery (SSRF) if an attacker controls the output prefix.
- Logic errors or crashes due to unsupported orientation types or negative range clusters.

🔧 Fix:
- Sanitized `$command_line` at the start of `svre.pl` by replacing all newline and carriage return characters with spaces.
- Added a check in the output path validation section to block any string containing `://`.
- Implemented strict validation for the `-ori` parameter, allowing only "FR" or "FF".
- Added a check to ensure the `-range` parameter is a valid non-negative number using `sv::isfloat`.

✅ Verification:
- Created and ran a comprehensive test script (`test_security_fixes.pl`) that verified each fix:
    - Confirmed newlines in arguments are sanitized.
    - Confirmed `://` in output prefix is rejected.
    - Confirmed invalid `ori` values are rejected.
    - Confirmed negative `range` values are rejected.
- Ran the full suite of existing tests (`test_validation.pl`, `test_snr_security.pl`, etc.) to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [16078292297001442402](https://jules.google.com/task/16078292297001442402) started by @swainechen*