### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix data corruption and DoS in sv::ric

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -161,3 +161,8 @@
 1. Explicitly block input strings that start with `|` when they will be used as filenames in R.
 2. Use temporary files to pass large metadata collections between processes instead of relying on command-line arguments.
 3. Use robust `read.table` parameters (`quote=""`, `comment.char=""`) to handle untrusted data within files.
+
+## 2025-05-25 - Data Integrity and DoS via Negative Array Indexing in Bin Merging
+**Vulnerability:** The `sv::ric` function in `sv.pm` was susceptible to data corruption and script crashes (DoS) when processing chromosomes with exactly one small genomic bin. Due to Perl's negative array indexing, a check for the "previous" bin (`$sortbin[$#sortbin - 1]`) would return the first bin itself if only one existed, causing the bin to merge with itself (doubling its count) and then delete itself.
+**Learning:** In languages that support negative array indexing (like Perl or Python), boundary checks using offsets from the array length must explicitly verify that the array has sufficient elements to prevent unintentional self-reference or wrap-around behavior.
+**Prevention:** Always use `scalar(@array) >= N` or explicit index bounds checks before accessing array elements using negative offsets or calculated indices near the boundaries.

--- a/sv.pm
+++ b/sv.pm
@@ -1129,6 +1129,9 @@ sub ric {
       $rcount = $count->{$ref}->{$bin}->{rcount};
       $bin_size = $count->{$ref}->{$bin}->{pos};
 
+      # Security: Ensure merging only happens if at least two bins exist for the chromosome.
+      # This prevents a single small bin from merging with itself (due to Perl's negative
+      # array indexing) and then being deleted, which causes data corruption and DoS.
       if ($bin == $sortbin[0] && defined($sortbin[1]) && $rcount < $cov_bin/2) {
         $count->{$ref}->{$sortbin[1]}->{rcount} += $rcount;
         $count->{$ref}->{$sortbin[1]}->{pos} += $bin_size;
@@ -1142,8 +1145,8 @@ sub ric {
         delete($count->{$ref}->{$sortbin[0]});
         next BIN;
       }
-	  
-      if (defined($sortbin[$#sortbin - 1]) && $bin == $sortbin[$#sortbin - 1] && $count->{$ref}->{$sortbin[$#sortbin]}->{rcount} < $cov_bin/2) {
+
+      if (scalar(@sortbin) >= 2 && defined($sortbin[$#sortbin - 1]) && $bin == $sortbin[$#sortbin - 1] && $count->{$ref}->{$sortbin[$#sortbin]}->{rcount} < $cov_bin/2) {
         $count->{$ref}->{$bin}->{rcount} += $count->{$ref}->{$sortbin[$#sortbin]}->{rcount};
         $count->{$ref}->{$bin}->{pos} += $count->{$ref}->{$sortbin[$#sortbin]}->{pos};
         push @{$count->{$ref}->{$bin}->{pair}}, @{$count->{$ref}->{$sortbin[$#sortbin]}->{pair}};

--- a/test_ric_bug.pl
+++ b/test_ric_bug.pl
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+
+# Mocking dependencies
+BEGIN {
+    $INC{"Math/Round.pm"} = 1;
+    package Math::Round;
+    use Exporter 'import';
+    our @EXPORT = qw(round);
+    sub round { return int($_[0] + 0.5); }
+
+    $INC{"Math/CDF.pm"} = 1;
+    package Math::CDF;
+    sub pnorm { return 0.5; }
+
+    $INC{"Math/Trig.pm"} = 1;
+    package Math::Trig;
+    use Exporter 'import';
+    our @EXPORT = qw(pi);
+    sub pi { return 3.14159; }
+
+    $INC{"Math/BigFloat.pm"} = 1;
+    package Math::BigFloat;
+    sub new { return bless {}, $_[0]; }
+    sub bpow { return $_[0]; }
+    sub bfac { return $_[0]; }
+    sub bmul { return $_[0]; }
+    sub bdiv { return $_[0]; }
+}
+
+use lib '.';
+require 'sv.pm';
+use Data::Dumper;
+
+my $refh = { "chr1" => 1000 };
+# We need to make sure we only have ONE bin.
+# ric bins by coverage. If we have few reads, we get one bin.
+# Note: ric expects precount->{$ref}->{$i}->{pair} to be an array ref if defined.
+my $precount = { "chr1" => { 10 => { 100 => 10, "pair" => [] } } };
+my $cov_bin = 100; # rcount 10 < cov_bin/2 (50)
+my $global_dist = { 100 => 1 };
+
+my ($ri, $count) = sv::ric($refh, $precount, $cov_bin, $global_dist);
+print "RI for chr1: ", Dumper($ri->{chr1});
+print "Count for chr1: ", Dumper($count->{chr1});


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `sv::ric` function in `sv.pm` had a logic bug where a chromosome with exactly one genomic bin (whose read count was less than half the coverage threshold) would attempt to merge with itself due to Perl's negative array indexing.
🎯 Impact: This caused data corruption (the bin's count was doubled) and then the bin was deleted from the data structure. Subsequent attempts by `svre.pl` to access this bin's details would result in "uninitialized value" or "not a hash reference" errors, potentially leading to a script crash (DoS).
🔧 Fix: Added a guard `scalar(@sortbin) >= 2` to ensure that bin merging only occurs when there are at least two bins available for a chromosome.
✅ Verification: Created a reproduction script `test_ric_bug.pl` that mocks dependencies and confirms that a single small bin is correctly preserved after the fix, rather than being doubled and deleted.

---
*PR created automatically by Jules for task [644290912805870045](https://jules.google.com/task/644290912805870045) started by @swainechen*