### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix logic vulnerability in sv::overlap

### DIFF
--- a/sv.pm
+++ b/sv.pm
@@ -171,11 +171,12 @@ sub overlap {
   my @r = split /,/, $r;
   my @s = split /,/, $s;
   foreach $i (@r) {
-    if (isfloat($i)) {
-      $f1 = $i;
-      $l1 = $i;
+    ($f1, $l1) = split /\.\./, $i;
+    $f1 =~ s/___.*$//;
+    if (defined $l1) {
+      $l1 =~ s/___.*$//;
     } else {
-      ($f1, $l1) = split /\.\./, $i;
+      $l1 = $f1;
     }
     $f1 = abs($f1);
     $l1 = abs($l1);
@@ -185,11 +186,12 @@ sub overlap {
       $l1 = $t;
     }
     foreach $j (@s) {
-      if (isfloat($j)) {
-        $f2 = $j;
-        $l2 = $j;
+      ($f2, $l2) = split /\.\./, $j;
+      $f2 =~ s/___.*$//;
+      if (defined $l2) {
+        $l2 =~ s/___.*$//;
       } else {
-        ($f2, $l2) = split /\.\./, $j;
+        $l2 = $f2;
       }
       $f2 = abs($f2);
       $l2 = abs($l2);

--- a/test_overlap_fix.pl
+++ b/test_overlap_fix.pl
@@ -1,0 +1,69 @@
+use strict;
+use warnings;
+use lib '.';
+
+# Mock dependencies for sv.pm
+BEGIN {
+    $INC{'Math/Round.pm'} = 1;
+    {
+        package Math::Round;
+        sub round { return int($_[0] + 0.5); }
+    }
+    $INC{'Math/CDF.pm'} = 1;
+    {
+        package Math::CDF;
+        sub pnorm { return 0.5; }
+    }
+    $INC{'Math/Trig.pm'} = 1;
+    {
+        package Math::Trig;
+        use constant pi => 3.14159265358979;
+        sub import {
+            no strict 'refs';
+            *{(caller)[0].'::pi'} = \&pi;
+        }
+    }
+    $INC{'Math/BigFloat.pm'} = 1;
+    {
+        package Math::BigFloat;
+        sub new { return bless {}, shift; }
+    }
+}
+
+require sv;
+
+my $failed = 0;
+
+sub assert_overlap {
+    my ($r, $s, $range, $expected, $msg) = @_;
+    my $result = sv::overlap($r, $s, $range);
+    if ($result == $expected) {
+        print "OK: $msg\n";
+    } else {
+        print "FAIL: $msg (Expected $expected, got $result)\n";
+        $failed = 1;
+    }
+}
+
+print "Starting tests for sv::overlap...\n";
+
+# Existing cases
+assert_overlap("100", "100", 0, 1, "Point 100 overlaps with 100");
+assert_overlap("100___ref", "100___ref", 0, 1, "Point 100___ref overlaps with itself");
+assert_overlap("100___ref", "1", 0, 0, "Point 100___ref should NOT overlap with 1");
+assert_overlap("100___ref", "90..110", 0, 1, "Point 100___ref overlaps with range 90..110");
+assert_overlap("100___ref", "90..110___ref", 0, 1, "Point 100___ref overlaps with range 90..110___ref");
+
+# Regression cases from code review
+assert_overlap("1.5..2.5", "2.0", 0, 1, "Float range 1.5..2.5 overlaps with 2.0");
+assert_overlap("1.5..2.5", "3.0", 0, 0, "Float range 1.5..2.5 should NOT overlap with 3.0");
+assert_overlap("100___ref..200___ref", "150", 0, 1, "Range 100___ref..200___ref overlaps with 150");
+assert_overlap("1e2..2e2", "150", 0, 1, "Scientific notation 1e2..2e2 overlaps with 150");
+
+if ($failed) {
+    print "\nSome tests FAILED.\n";
+    exit 1;
+} else {
+    print "\nAll tests PASSED.\n";
+    exit 0;
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Point coordinates containing chromosome suffixes (e.g., "100___ref") were incorrectly parsed by sv::overlap. Because they failed the isfloat() check, they were processed via split /\.\./, resulting in an undefined upper bound that Perl numified to 0. This turned points into ranges starting from 0 (e.g., [0, 100]), leading to incorrect structural variation merging.

🎯 Impact: Data integrity issues and logic bypasses during structural variation reporting.

🔧 Fix: Refactored sv::overlap to robustly handle both point and range formats by splitting on '..' and explicitly stripping suffixes (s/___.*$//) from all coordinates. This ensures correct parsing for integers, floats, and scientific notation.

✅ Verification: Created test_overlap_fix.pl covering integer points, suffixed points, floating point ranges, and scientific notation. All tests passed, and existing test suite verified no regressions.

---
*PR created automatically by Jules for task [7558062955210872820](https://jules.google.com/task/7558062955210872820) started by @swainechen*