### PR TITLE
🛡️ Sentinel: [HIGH] Fix Regex Line Anchor Bypass in validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -162,6 +162,11 @@
 2. Use temporary files to pass large metadata collections between processes instead of relying on command-line arguments.
 3. Use robust `read.table` parameters (`quote=""`, `comment.char=""`) to handle untrusted data within files.
 
+## 2025-06-25 - Regex Line Anchor Bypass (Newline Injection) in Perl
+**Vulnerability:** Use of the `$` anchor in validation regexes allowed strings with trailing newlines to pass as valid numeric or coordinate data. This could lead to log injection or logic bypasses when the data is later used.
+**Learning:** In Perl, the `$` anchor matches at the end of the string OR before a newline at the end of the string. The `\z` anchor is the strict end-of-string anchor.
+**Prevention:** Always use `\z` instead of `$` for strict end-of-string validation in Perl. Avoid `chomp` within validation functions if they are intended to be pure validators, as `chomp` modifies the input (if not used on a copy) and can mask malformed data.
+
 ## 2025-05-25 - Data Integrity and DoS via Negative Array Indexing in Bin Merging
 **Vulnerability:** The `sv::ric` function in `sv.pm` was susceptible to data corruption and script crashes (DoS) when processing chromosomes with exactly one small genomic bin. Due to Perl's negative array indexing, a check for the "previous" bin (`$sortbin[$#sortbin - 1]`) would return the first bin itself if only one existed, causing the bin to merge with itself (doubling its count) and then delete itself.
 **Learning:** In languages that support negative array indexing (like Perl or Python), boundary checks using offsets from the array length must explicitly verify that the array has sufficient elements to prevent unintentional self-reference or wrap-around behavior.

--- a/sv.pm
+++ b/sv.pm
@@ -50,19 +50,20 @@ sub range {
   foreach $i (@$input_a) {
     @f = split /,/, $i;
     foreach $j (0..$#f) {
-      if ($f[$j] =~ /^(.+?)$ranger_re(.+?)$/) {
+      # Security: Use \z instead of $ to prevent newline bypass
+      if ($f[$j] =~ /^(.+?)$ranger_re(.+?)\z/) {
         my ($left, $right) = ($1, $2);
         my ($p0_val, $r0_val, $p1_val, $r1_val);
 
         if (isfloat($left)) {
           $p0_val = $left;
-        } elsif ($left =~ /^(-?\d+)___(\S+)$/) {
+        } elsif ($left =~ /^(-?\d+)___(\S+)\z/) {
           ($p0_val, $r0_val) = ($1, $2);
         }
 
         if (isfloat($right)) {
           $p1_val = $right;
-        } elsif ($right =~ /^(-?\d+)___(\S+)$/) {
+        } elsif ($right =~ /^(-?\d+)___(\S+)\z/) {
           ($p1_val, $r1_val) = ($1, $2);
         }
 
@@ -83,14 +84,14 @@ sub range {
       if ($#g == 0) {
         if (isfloat($g[0])) {
           push @{$arrays->{__NUMBERS__}}, [$g[0], $g[0]];
-        } elsif ($g[0] =~ /^(-?\d+)___(\S+)$/) {
+        } elsif ($g[0] =~ /^(-?\d+)___(\S+)\z/) {
           push @{$arrays->{$2}}, [$1, $1];
         }
       } elsif ($#g == 1) {
         my ($l, $ri) = ($g[0], $g[1]);
         my ($p0_v, $r0_v, $p1_v, $r1_v);
-        if (isfloat($l)) { $p0_v = $l; } elsif ($l =~ /^(-?\d+)___(\S+)$/) { ($p0_v, $r0_v) = ($1, $2); }
-        if (isfloat($ri)) { $p1_v = $ri; } elsif ($ri =~ /^(-?\d+)___(\S+)$/) { ($p1_v, $r1_v) = ($1, $2); }
+        if (isfloat($l)) { $p0_v = $l; } elsif ($l =~ /^(-?\d+)___(\S+)\z/) { ($p0_v, $r0_v) = ($1, $2); }
+        if (isfloat($ri)) { $p1_v = $ri; } elsif ($ri =~ /^(-?\d+)___(\S+)\z/) { ($p1_v, $r1_v) = ($1, $2); }
         if (defined $p0_v && defined $p1_v) {
           my $f_ref = $r0_v // $r1_v;
           my $t_key = defined $f_ref ? $f_ref : "__NUMBERS__";
@@ -147,10 +148,10 @@ sub absrange {	# same as above but return only absolute values
   foreach $i (@$a_ref) {
     if (isfloat($i)) {
       push @$abs_coords, abs($i);
-    } elsif ($i =~ /^(-?\d+)___(\S+)$/) {
+    } elsif ($i =~ /^(-?\d+)___(\S+)\z/) {
       push @$abs_coords, abs($1) . "___" . $2;
     } else {
-      if ($i =~ /^(-?\d+)\.\.(-?\d+)(?:___(\S+))?$/) {
+      if ($i =~ /^(-?\d+)\.\.(-?\d+)(?:___(\S+))?\z/) {
         my $suffix = defined $3 ? "___$3" : "";
         push @$abs_coords, abs($1) . ".." . abs($2) . $suffix;
       }
@@ -1039,8 +1040,8 @@ sub isfloat {
   if (!defined $string) {
     return 0;
   }
-  chomp $string;
-  if ($string =~ /^([+-])?(?=\d|\.\d)\d*(\.\d*)?([Ee]([+-]?\d+))?$/) {
+  # Security: Use \z instead of $ to prevent matching strings with trailing newlines (Log Injection/Bypass)
+  if ($string =~ /^([+-])?(?=\d|\.\d)\d*(\.\d*)?([Ee]([+-]?\d+))?\z/) {
     return 1;
   } else {
     return 0;
@@ -1263,7 +1264,7 @@ sub unwind_distance {
     next if !defined $precount->{$ref}->{$i}->{$dist};
     next if !defined $precount->{$ref}->{$i}->{pair};	# should never happen
     foreach $j (@{$precount->{$ref}->{$i}->{pair}}) {
-      next if $j !~ /^[+-]?\d+$/;
+      next if $j !~ /^[+-]?\d+\z/;
       if ($j > $i) {
         $r->{first} = 1;
       } else {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Regex Line Anchor Bypass (Newline Injection)
🎯 Impact: Strings with trailing newlines (e.g., from un-chomped user input or malformed data) were accepted as valid floats or genomic ranges. This could lead to log injection in output files or bypass security checks that assume validated data is clean.
🔧 Fix: Switched from the ambiguous "$" anchor to the strict "\z" anchor in sv.pm"s isfloat, range, absrange, and unwind_distance functions. Removed chomp from isfloat to ensure it acts as a pure, strict validator.
✅ Verification: Created and ran repro_newline_injection.pl which confirmed that inputs with newlines are now correctly rejected. Verified that all existing tests (test_*.pl) pass with these changes.

---
*PR created automatically by Jules for task [9956681783383191791](https://jules.google.com/task/9956681783383191791) started by @swainechen*