### PR TITLE
🛡️ Sentinel: Fix redundant output and harden regexes

### DIFF
--- a/sv.pm
+++ b/sv.pm
@@ -214,6 +214,8 @@ sub overlap {
 
 # check if given number is within an array of numbers
 sub pair_check {
+  # Security: harden against DoS by validating array reference and arguments
+  return () if !defined $_[0] || ref($_[0]) ne 'ARRAY' || !defined $_[1];
   my @pairs = @{$_[0]}; # always pass the array as a reference to the sub when calling
   my $a_string = $_[1];  # joined (with ,) string of numbers or ranges 
   my $pos = $_[2];

--- a/svre.pl
+++ b/svre.pl
@@ -1174,7 +1174,7 @@ if ($pval) {
           my $t_ref = $dist;
           $t_ref =~ s/^-?\d+___//;
           my $t_pos = $dist;
-          $t_pos =~ s/___.*$//;
+          $t_pos =~ s/___.*\z//s;
           my $t_ref_len = defined $refh->{$t_ref} ? $refh->{$t_ref} : 10000000;
           $sv->{$dist}->{target} = sv::refadd($t_pos, -($ri->{$ref}->{$bin}->{binsize}), $t_ref_len) . ".." . sv::refadd($t_pos, $ri->{$ref}->{$bin}->{binsize}, $t_ref_len) . "___$t_ref";
           next;
@@ -1295,6 +1295,7 @@ if ($pval) {
               $merge_sv->{$merge_i}->{bp2}->{ref} =~ s/^-?\d+(\.\.-?\d+)?___//;
               $merge_sv->{$merge_i}->{bp1}->{coord} = abs($bin) . ".." . (abs($bin) + $ri->{$ref}->{$bin}->{binsize} + 1);	# to make sure we overlap later with the next bin
               $merge_sv->{$merge_i}->{bp2}->{coord} = sv::absrange(\@r, $range_cluster);
+              $merge_sv->{$merge_i}->{bp2}->{coord} =~ s/___.*\z//s;
             }
           }
           # Fix: Correctly initialize variables for the next group using current element
@@ -1322,6 +1323,7 @@ if ($pval) {
           $merge_sv->{$merge_i}->{bp2}->{ref} =~ s/^-?\d+(\.\.-?\d+)?___//;
           $merge_sv->{$merge_i}->{bp1}->{coord} = abs($bin) . ".." . (abs($bin) + $ri->{$ref}->{$bin}->{binsize} + 1);	# to make sure we overlap later with the next bin
           $merge_sv->{$merge_i}->{bp2}->{coord} = sv::absrange(\@r, $range_cluster);
+          $merge_sv->{$merge_i}->{bp2}->{coord} =~ s/___.*\z//s;
         }
       }
       if ($bin >= 0) {

--- a/test_newline_bypass.pl
+++ b/test_newline_bypass.pl
@@ -1,6 +1,25 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
+
+BEGIN {
+    package Math::Round;
+    use Exporter 'import';
+    our @EXPORT = qw(round);
+    sub round { my $x = shift; return int($x + 0.5 * ($x <=> 0)); }
+    $INC{'Math/Round.pm'} = 1;
+
+    package Math::CDF;
+    sub pnorm { return 0.5; }
+    $INC{'Math/CDF.pm'} = 1;
+
+    package Math::Trig;
+    use Exporter 'import';
+    our @EXPORT = qw(pi);
+    sub pi { return 3.14159265358979; }
+    $INC{'Math/Trig.pm'} = 1;
+}
+
 use File::Spec;
 use lib '.';
 use sv;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Redundant chromosome suffixes in translocation reports and potential newline bypass in regexes.
🎯 Impact: Unclean output data and potential logic bypass or log injection via crafted inputs containing newlines.
🔧 Fix:
- Stripped redundant suffixes (e.g., `___chr2`) from `bp2->coord` in `svre.pl` translocation reporting.
- Updated coordinate stripping regexes to use `\z` and `/s` for robust end-of-string matching.
- Added input validation to `sv::pair_check` in `sv.pm` to prevent crashes when provided with malformed or undefined references.
✅ Verification: Verified the translocation output fix and newline bypass prevention using `test_translocation_output.pl` and an updated `test_newline_bypass.pl`.

---
*PR created automatically by Jules for task [3339613546944962118](https://jules.google.com/task/3339613546944962118) started by @swainechen*