### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden SAM header validation and translocation reporting

### DIFF
--- a/svre.pl
+++ b/svre.pl
@@ -314,7 +314,8 @@ foreach $i (@samheader1) {
         $j = $1;
       }
     }
-    if ($ref ne "" && $j) {
+    if ($ref ne "") {
+      die "Error: Missing or zero length (LN) for chromosome $ref in SAM header 1\n" if !$j || $j <= 0;
       $refh->{$ref} = $j;
     }
   }
@@ -343,10 +344,14 @@ foreach $i (@samheader2) {
         $j = $1;
       }
     }
-    if ($ref ne "" && $j) {
-     die "SAM headers don't match on line $i\n" if !defined $refh->{$ref} || $refh->{$ref} != $j;
+    if ($ref ne "") {
+     die "Error: Missing or zero length (LN) for chromosome $ref in SAM header 2\n" if !$j || $j <= 0;
+     die "SAM headers don't match for chromosome $ref\n" if !defined $refh->{$ref} || $refh->{$ref} != $j;
     }
   }
+}
+if (! %$refh) {
+  die "Error: No valid chromosomes found in SAM headers. Check that your BAM files have \@SQ lines.\n";
 }
 
 #@@@@@@@@@@@@@@@@@@@@@
@@ -1175,7 +1180,8 @@ if ($pval) {
           $t_ref =~ s/^-?\d+___//;
           my $t_pos = $dist;
           $t_pos =~ s/___.*\z//s;
-          my $t_ref_len = defined $refh->{$t_ref} ? $refh->{$t_ref} : 10000000;
+          die "Error: Translocation target reference $t_ref not found in SAM header\n" if !defined $refh->{$t_ref};
+          my $t_ref_len = $refh->{$t_ref};
           $sv->{$dist}->{target} = sv::refadd($t_pos, -($ri->{$ref}->{$bin}->{binsize}), $t_ref_len) . ".." . sv::refadd($t_pos, $ri->{$ref}->{$bin}->{binsize}, $t_ref_len) . "___$t_ref";
           next;
         }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing or weak validation of SAM header metadata and translocation target references.
🎯 Impact: Malformed input files (e.g., with zero-length chromosomes) could lead to logic errors, incorrect structural variation calls, or potential division-by-zero crashes. Using a "magic" default length for unknown translocation targets could result in incorrect coordinate normalization.
🔧 Fix:
- Implemented strict validation for chromosome lengths in @SQ header lines.
- Ensured consistency of chromosome metadata across input files.
- Replaced insecure default length for translocation targets with a fatal error if the reference is unknown.
- Added a check to ensure at least one valid chromosome is present.
✅ Verification:
- Verified that existing tests pass.
- Created and ran a new header validation test suite that confirms the script correctly rejects headers with missing/zero lengths or mismatched metadata.
- Performed syntax checks on the modified script.

---
*PR created automatically by Jules for task [12214880775288964968](https://jules.google.com/task/12214880775288964968) started by @swainechen*