### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden reference length validation in sv.pm

### DIFF
--- a/sv.pm
+++ b/sv.pm
@@ -1319,7 +1319,10 @@ sub refmod {
   my ($coord, $ref) = @_;
 
   # Security: prevent division-by-zero or infinite loops if ref is 0 or negative
-  return $coord if !$ref || $ref <= 0;
+  if (!$ref || $ref <= 0) {
+    warn "Warning: reference length must be strictly positive in sv::refmod. Returning un-normalized coordinate.\n";
+    return $coord;
+  }
 
   if ($coord == 0) {
     return $ref;
@@ -1346,7 +1349,11 @@ sub refadd {
   my ($a_val, $b_val, $ref) = @_;
   my $return;
   return $a_val if $b_val == 0;
-  $ref = 10000000 if $ref <= 0;
+  # Security: ensure reference length is strictly positive to prevent coordinate corruption (DoS)
+  if (!$ref || $ref <= 0) {
+    warn "Warning: reference length must be strictly positive in sv::refadd. Using default constant.\n";
+    $ref = 10000000;
+  }
   my $a_temp = $a_val;
   $a_temp = $ref if $a_temp == 0;
   $return = $a_temp + $b_val;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The utility functions `sv::refadd` and `sv::refmod` lacked robust validation for the reference length (`$ref`) parameter. While `sv::refmod` had a guard to prevent infinite loops, `sv::refadd` used an insecure magic constant (10000000) as a fallback for non-positive reference lengths.
🎯 Impact: Metadata inconsistencies or malformed genomic data could lead to coordinate corruption or unexpected behavior in downstream structural variation calling. Insecure defaults make it harder to detect data integrity issues during processing.
🔧 Fix: Added explicit validation for the reference length in both `sv::refadd` and `sv::refmod`. If a non-positive length is encountered, the functions now issue a `warn` to alert the user/developer and use safe fallbacks (returning the un-normalized coordinate or using the existing default constant) to maintain application availability and backward compatibility with the library.
✅ Verification: Created a temporary verification script that mocks dependencies and confirms that `warn` is triggered and fallback behavior is preserved when `$ref` is 0 or negative. Also ran the full existing test suite to ensure no regressions.

---
*PR created automatically by Jules for task [2432203029438129263](https://jules.google.com/task/2432203029438129263) started by @swainechen*