### PR TITLE
🛡️ Sentinel: Hardened regex validation and line-ending handling

### DIFF
--- a/svre.pl
+++ b/svre.pl
@@ -278,22 +278,22 @@ my $mapper = "";
 my $mapper_version = "";
 my $mapper_command_line = "";
 
-if ($r1 =~ /\.sam$/i) {
+if ($r1 =~ /\.sam\z/i) {
   open(my $ph, "-|", $samtools_command, "view", "-SH", "--", $r1) or die "Can't open samtools: $!\n";
   @samheader1 = <$ph>;
   close($ph) or die "Error closing samtools pipe: $!\n";
-} elsif ($r1 =~ /\.bam$/i) {
+} elsif ($r1 =~ /\.bam\z/i) {
   open(my $ph, "-|", $samtools_command, "view", "-H", "--", $r1) or die "Can't open samtools: $!\n";
   @samheader1 = <$ph>;
   close($ph) or die "Error closing samtools pipe: $!\n";
 } else {
   die "Can't figure out $r1 file type (sam/bam)\n";
 }
-if ($r2 =~ /\.sam$/i) {
+if ($r2 =~ /\.sam\z/i) {
   open(my $ph, "-|", $samtools_command, "view", "-SH", "--", $r2) or die "Can't open samtools: $!\n";
   @samheader2 = <$ph>;
   close($ph) or die "Error closing samtools pipe: $!\n";
-} elsif ($r2 =~ /\.bam$/i) {
+} elsif ($r2 =~ /\.bam\z/i) {
   open(my $ph, "-|", $samtools_command, "view", "-H", "--", $r2) or die "Can't open samtools: $!\n";
   @samheader2 = <$ph>;
   close($ph) or die "Error closing samtools pipe: $!\n";
@@ -409,13 +409,14 @@ if (-B $r1) {
   open($rh1, "<", $r1) or die "Can't open $r1: $!\n";
 }
 while (<$rh1>) {
-  chomp;
+  s/[\r\n]+\z//;
   @f = split /\t/, $_;
   # Security: harden SAM tag validation to prevent logic bypass from spoofed tags
   # in QNAME, SEQ, or QUAL fields. Validate tags only in fields 12+ (index 11+).
+  # Use \z anchor to prevent newline bypass.
   my %tags = ();
   for (my $tag_idx = 11; $tag_idx <= $#f; $tag_idx++) {
-    if ($f[$tag_idx] =~ /^([^:]+:[^:]+):(.*)$/) {
+    if ($f[$tag_idx] =~ /^([^:]+:[^:]+):(.*)\z/) {
       $tags{$1} = $2;
     }
   }
@@ -461,13 +462,14 @@ if (-B $r2) {
   open($rh2, "<", $r2) or die "Can't open $r2: $!\n";
 }
 while (<$rh2>){
-  chomp;
+  s/[\r\n]+\z//;
   @f = split /\t/, $_;
   # Security: harden SAM tag validation to prevent logic bypass from spoofed tags
   # in QNAME, SEQ, or QUAL fields. Validate tags only in fields 12+ (index 11+).
+  # Use \z anchor to prevent newline bypass.
   my %tags = ();
   for (my $tag_idx = 11; $tag_idx <= $#f; $tag_idx++) {
-    if ($f[$tag_idx] =~ /^([^:]+:[^:]+):(.*)$/) {
+    if ($f[$tag_idx] =~ /^([^:]+:[^:]+):(.*)\z/) {
       $tags{$1} = $2;
     }
   }

--- a/test_newline_validation.pl
+++ b/test_newline_validation.pl
@@ -1,0 +1,56 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+sub parse_tags {
+    my $line = shift;
+    $line =~ s/[\r\n]+\z//;
+    my @f = split /\t/, $line;
+    my %tags = ();
+    for (my $tag_idx = 11; $tag_idx <= $#f; $tag_idx++) {
+        if ($f[$tag_idx] =~ /^([^:]+:[^:]+):(.*)\z/) {
+            $tags{$1} = $2;
+        }
+    }
+    return \%tags;
+}
+
+print "Testing SAM tag parsing with CRLF...\n";
+my $line_crlf = "read1\t0\tchr1\t100\t60\t75M\t*\t0\t0\tA\tB\tNM:i:0\r\n";
+my $tags = parse_tags($line_crlf);
+if (exists $tags->{"NM:i"} && $tags->{"NM:i"} eq "0") {
+    print "PASS: Tag matched correctly with CRLF.\n";
+} else {
+    print "FAIL: Tag did not match with CRLF! (Value: " . ($tags->{"NM:i"} // "undef") . ")\n";
+    exit 1;
+}
+
+print "Testing SAM tag parsing with LF only...\n";
+my $line_lf = "read1\t0\tchr1\t100\t60\t75M\t*\t0\t0\tA\tB\tNM:i:0\n";
+$tags = parse_tags($line_lf);
+if (exists $tags->{"NM:i"} && $tags->{"NM:i"} eq "0") {
+    print "PASS: Tag matched correctly with LF.\n";
+} else {
+    print "FAIL: Tag did not match with LF!\n";
+    exit 1;
+}
+
+print "Testing file extension check with \\z...\n";
+my $valid_bam = "test.bam";
+if ($valid_bam =~ /\.bam\z/i) {
+    print "PASS: Valid filename matched extension.\n";
+} else {
+    print "FAIL: Valid filename did not match extension!\n";
+    exit 1;
+}
+
+my $bam_with_newline = "test.bam\n";
+if ($bam_with_newline =~ /\.bam\z/i) {
+    print "FAIL: Filename with newline matched extension! (Potential bypass)\n";
+    exit 1;
+} else {
+    print "PASS: Filename with newline rejected.\n";
+}
+
+print "ALL NEWLINE VALIDATION TESTS PASSED.\n";
+exit 0;


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Regex Line Anchor Bypass

🚨 Severity: MEDIUM
💡 Vulnerability: Regex Line Anchor Bypass (Newline Injection)
🎯 Impact: Malformed or malicious input containing trailing newlines could bypass validation checks or cause logic errors during SAM tag parsing and file extension validation. In some environments, this could lead to log injection or unexpected application behavior.
🔧 Fix:
- Replaced `$` anchors with `\z` in `svre.pl` for strict end-of-string validation.
- Replaced `chomp;` with `s/[\r\n]+\z//;` to robustly handle CRLF/LF line endings and prevent trailing characters from interfering with strict anchors.
✅ Verification: Created `test_newline_validation.pl` which verifies tag parsing and extension validation with LF, CRLF, and malicious newline-injected strings. Ran the full project test suite to ensure no functional regressions.

---
*PR created automatically by Jules for task [17331177254042014851](https://jules.google.com/task/17331177254042014851) started by @swainechen*