### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix translocation metadata stripping

### DIFF
--- a/svre.pl
+++ b/svre.pl
@@ -1374,7 +1374,7 @@ if ($pval) {
               # Fix: Use the correct reference from the group being reported.
               # Security: Robustly strip metadata prefix to prevent variable contamination.
               $merge_sv->{$merge_i}->{bp2}->{ref} = $current_targets[0];
-              $merge_sv->{$merge_i}->{bp2}->{ref} =~ s/^\${RE_INT}(?:\.\.\${RE_INT})?___//;
+              $merge_sv->{$merge_i}->{bp2}->{ref} =~ s/^${RE_INT}(?:\.\.${RE_INT})?___//;
               $merge_sv->{$merge_i}->{bp1}->{coord} = abs($bin) . ".." . (abs($bin) + $ri->{$ref}->{$bin}->{binsize} + 1);	# to make sure we overlap later with the next bin
               $merge_sv->{$merge_i}->{bp2}->{coord} = sv::absrange(\@current_targets, $range_cluster);
               $merge_sv->{$merge_i}->{bp2}->{coord} =~ s/___.*\z//s;
@@ -1402,7 +1402,7 @@ if ($pval) {
           # Fix: Use the correct reference from the group being reported.
           # Security: Robustly strip metadata prefix to prevent variable contamination.
           $merge_sv->{$merge_i}->{bp2}->{ref} = $current_targets[0];
-          $merge_sv->{$merge_i}->{bp2}->{ref} =~ s/^\${RE_INT}(?:\.\.\${RE_INT})?___//;
+          $merge_sv->{$merge_i}->{bp2}->{ref} =~ s/^${RE_INT}(?:\.\.${RE_INT})?___//;
           $merge_sv->{$merge_i}->{bp1}->{coord} = abs($bin) . ".." . (abs($bin) + $ri->{$ref}->{$bin}->{binsize} + 1);	# to make sure we overlap later with the next bin
           $merge_sv->{$merge_i}->{bp2}->{coord} = sv::absrange(\@current_targets, $range_cluster);
           $merge_sv->{$merge_i}->{bp2}->{coord} =~ s/___.*\z//s;

--- a/test_metadata_stripping_fix.pl
+++ b/test_metadata_stripping_fix.pl
@@ -1,0 +1,62 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use File::Spec;
+use lib '.';
+
+BEGIN {
+    # Mocking Math::Round
+    package Math::Round;
+    $INC{"Math/Round.pm"} = "mock";
+    sub round { int($_[0] + 0.5) }
+    require Exporter;
+    @Math::Round::ISA = qw(Exporter);
+    @Math::Round::EXPORT = qw(round);
+
+    # Mocking Math::Trig
+    package Math::Trig;
+    $INC{"Math/Trig.pm"} = "mock";
+    sub pi () { 3.14159265358979 }
+    @Math::Trig::ISA = qw(Exporter);
+    @Math::Trig::EXPORT = qw(pi);
+
+    # Mocking Math::CDF
+    package Math::CDF;
+    $INC{"Math/CDF.pm"} = "mock";
+
+    # Mocking Math::BigFloat
+    package Math::BigFloat;
+    $INC{"Math/BigFloat.pm"} = "mock";
+}
+
+use sv;
+
+my $RE_INT = $sv::RE_INT;
+
+my @tests = (
+    { input => "100___chr1", expected => "chr1" },
+    { input => "100..200___chr1", expected => "chr1" },
+    { input => "+100___chr2", expected => "chr2" },
+    { input => "-100..-50___chr3", expected => "chr3" },
+    { input => "100", expected => "100" }, # should not change if it doesn't match the full pattern including ___
+);
+
+my $pass = 1;
+foreach my $test (@tests) {
+    my $val = $test->{input};
+    $val =~ s/^${RE_INT}(?:\.\.${RE_INT})?___//;
+    if ($val eq $test->{expected}) {
+        print "PASS: '$test->{input}' -> '$val'\n";
+    } else {
+        print "FAIL: '$test->{input}' -> '$val' (expected '$test->{expected}')\n";
+        $pass = 0;
+    }
+}
+
+if ($pass) {
+    print "All metadata stripping tests passed!\n";
+    exit 0;
+} else {
+    print "Some metadata stripping tests failed.\n";
+    exit 1;
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Incorrectly escaped regex variable prevented metadata stripping in svre.pl.
🎯 Impact: Translocation target reference names were corrupted with coordinate prefixes (e.g., "100..200___chr1" instead of "chr1"), leading to potential downstream logic failures or crashes if the corrupted name was used as a hash key.
🔧 Fix: Corrected `\${RE_INT}` to `${RE_INT}` in `svre.pl` regex substitutions to allow proper variable interpolation.
✅ Verification: Created and executed `test_metadata_stripping_fix.pl` which verifies the stripping logic against various input formats (integers, ranges, signed values). All tests passed.

---
*PR created automatically by Jules for task [11274361753378456714](https://jules.google.com/task/11274361753378456714) started by @swainechen*